### PR TITLE
Add struct-based configuration implementation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ linters:
     - ineffassign
     - misspell
     - nakedret
-    - nolintlint
+#    - nolintlint
     - prealloc
     - predeclared
     - revive

--- a/cfg/check.go
+++ b/cfg/check.go
@@ -1,0 +1,66 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxPort = (1 << 16) - 1
+
+//-----------------------------------------------------------------------------
+
+func checkPort(port int, min int, name []string) error {
+	if port < min || port > maxPort {
+		return fmt.Errorf("invalid %s network port: %d", field(name), port)
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func checkAddr(addr string, zeroHost bool, minPort int, name []string) error {
+	if len(addr) == 0 {
+		return fmt.Errorf("empty %s network address", field(name))
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("invalid %s %w", field(name), err)
+	}
+	if len(host) == 0 && !zeroHost {
+		return fmt.Errorf("missing %s host address", field(name))
+	}
+	var pnum int
+	pnum, err = strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("invalid %s network port: %q", field(name), port)
+	}
+	return checkPort(pnum, minPort, name)
+}
+
+//-----------------------------------------------------------------------------
+
+func checkRange(num, min, max int, name []string) error {
+	if num < min || num > max {
+		return fmt.Errorf("invalid %s value %d", field(name), num)
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func field(name []string) string {
+	return strings.Join(name, ".")
+}
+
+//-----------------------------------------------------------------------------
+
+func usec(n uint) time.Duration {
+	return time.Duration(n) * time.Second
+}

--- a/cfg/conf.go
+++ b/cfg/conf.go
@@ -1,0 +1,201 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cristalhq/aconfig"
+	"github.com/cristalhq/aconfig/aconfigyaml"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	AppName   = "omesrv"
+	CfgFile   = "omesrv.yaml"
+	EnvPrefix = "OME"
+)
+
+// ServerConfig represents global OME server configuration.
+type ServerConfig struct {
+	Http  HttpConfig //nolint
+	Grpc  GrpcConfig
+	Redis RedisConfig
+	flags *flag.FlagSet // command line arguments
+	files []string      // configuration files
+	exit  bool          // must exit
+	penv  bool          // print environment flag
+}
+
+var _cfg ServerConfig
+
+var (
+	Server = &_cfg
+	Http   = &_cfg.Http //nolint
+	Grpc   = &_cfg.Grpc
+	Redis  = &_cfg.Redis
+)
+
+// args mirrors os.Args sans program name.
+//
+// Used for testing.
+var args = os.Args[1:]
+
+const (
+	confFlag = "conf"
+	envFlag  = "env"
+)
+
+// Load performs loading of ServerConfig from a file,
+// environment, and command line arguments.
+func Load() error {
+	return _cfg.Load()
+}
+
+// Load performs loading of ServerConfig from a file,
+// environment, and command line arguments.
+func (c *ServerConfig) Load() error {
+	loader, err := c.createConfigLoader()
+	if err != nil {
+		return err
+	}
+	err = loader.Load()
+	if err == nil {
+		if c.penv {
+			c.printEnviron()
+			return nil
+		}
+		return c.Check()
+	}
+	if errors.Is(err, flag.ErrHelp) {
+		c.printHelp()
+		return nil
+	}
+	if cause := errors.Unwrap(err); cause != nil {
+		return cause
+	}
+	return err
+}
+
+// Check validates ServerConfig fields.
+func (c *ServerConfig) Check() (err error) {
+	if err = c.Http.Check("http"); err == nil {
+		if err = c.Grpc.Check("grpc"); err == nil {
+			err = c.Redis.Check("redis")
+		}
+	}
+	return
+}
+
+// AddConfigFile adds custom file path to the configuration search
+// locations.
+func (c *ServerConfig) AddConfigFile(file string) {
+	c.files = append(c.files, file)
+}
+
+// AddConfigDir adds a directory to the configuration file search
+// locations. Appended with default CfgFile name.
+func (c *ServerConfig) AddConfigDir(dir string) {
+	c.files = append(c.files, filepath.Join(dir, CfgFile))
+}
+
+// MustExit indicates that the process should exit. It is toggled in the
+// Load function.
+//
+// Most often it is true when help requested from the
+// command line arguments.
+func (c *ServerConfig) MustExit() bool {
+	return c.exit
+}
+
+//-----------------------------------------------------------------------------
+
+func (c *ServerConfig) createConfigLoader() (*aconfig.Loader, error) {
+	files, err := configSearch(CfgFile, c.files)
+	if err != nil {
+		return nil, err
+	}
+	loader := aconfig.LoaderFor(c, aconfig.Config{
+		SkipDefaults:       false,
+		SkipFiles:          false,
+		SkipEnv:            false,
+		SkipFlags:          false,
+		EnvPrefix:          EnvPrefix,
+		FlagPrefix:         "",
+		FlagDelimiter:      ".",
+		AllFieldRequired:   false,
+		AllowDuplicates:    false,
+		AllowUnknownFields: false,
+		AllowUnknownEnvs:   true,
+		AllowUnknownFlags:  true,
+		DontGenerateTags:   false,
+		FailOnFileNotFound: false,
+		MergeFiles:         false,
+		Args:               args,
+		FileFlag:           confFlag,
+		Files:              files,
+		FileDecoders: map[string]aconfig.FileDecoder{
+			".yaml": aconfigyaml.New(),
+		},
+	})
+	c.flags = loader.Flags()
+	c.flags.Usage = func() {}
+	c.flags.SetOutput(io.Discard)
+	c.flags.BoolVar(&c.penv, envFlag, false, "print environment variables")
+	return loader, nil
+}
+
+//-----------------------------------------------------------------------------
+// JSON
+//-----------------------------------------------------------------------------
+
+// WriteJSON writes JSON representation of ServerConfig to w.
+//
+// The resulting JSON is formatted with indents and new lines.
+func (c *ServerConfig) WriteJSON(w io.Writer) error {
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err == nil {
+		_, err = w.Write(b)
+	}
+	return err
+}
+
+// PrintJSON outputs ServerConfig JSON to os.Stdout.
+func (c *ServerConfig) PrintJSON() {
+	_ = c.WriteJSON(os.Stdout)
+}
+
+//-----------------------------------------------------------------------------
+// YAML
+//-----------------------------------------------------------------------------
+
+// WriteYAML writes YAML representation of ServerConfig to w.
+func (c *ServerConfig) WriteYAML(w io.Writer) error {
+	b, err := yaml.Marshal(c)
+	if err == nil {
+		_, err = w.Write(b)
+	}
+	return err
+}
+
+// PrintYAML outputs ServerConfig YAML to os.Stdout.
+func (c *ServerConfig) PrintYAML() {
+	_ = c.WriteYAML(os.Stdout)
+}
+
+// GetEnv lookups environment variable prefixed with EnvPrefix.
+//
+// Returns ok if variable found and has non-zero length.
+func GetEnv(key string) (val string, ok bool) {
+	const pfx = EnvPrefix + "_"
+	val, ok = os.LookupEnv(pfx + key)
+	ok = ok && len(val) > 0
+	return
+}

--- a/cfg/conf_test.go
+++ b/cfg/conf_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func init() {
+	args = []string{}
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_Load(t *testing.T) {
+	loadConfig(t)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_LoadEnv(t *testing.T) {
+	t.Setenv("OME_HTTP_ADDR", ":80")
+	t.Setenv("OME_GRPC_ADDR", ":90")
+	t.Setenv("OME_REDIS_STORE_POOL", "32")
+	t.Setenv("OME_REDIS_STORE_PASS", "SECRET")
+	loadConfig(t)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_LoadArg(t *testing.T) {
+	setArg("-http.addr", ":100", "-grpc.addr", ":110", "-redis.store.pass", "secret")
+	loadConfig(t)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_Help(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	setArg("-h")
+	err := Server.Load()
+	require.NoError(t, err)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_Env(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	setArg("-env")
+	err := Server.Load()
+	require.NoError(t, err)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestServerConfig_PrintJson(t *testing.T) {
+	logJSON(t, sampleConfig())
+}
+
+func TestServerConfig_PrintYaml(t *testing.T) {
+	logYAML(t, sampleConfig())
+}
+
+//-----------------------------------------------------------------------------
+
+func TestConfigSearch(t *testing.T) {
+	all, err := configSearch(CfgFile, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logJSON(t, all)
+}
+
+//-----------------------------------------------------------------------------
+
+func TestParseBytes(t *testing.T) {
+	n, err := strconv.Atoi("100")
+	require.NoError(t, err)
+	t.Logf("n = %d", n)
+}
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+func loadConfig(t testing.TB) {
+	err := Server.Load()
+	require.NoError(t, err)
+	if Server.MustExit() {
+		return
+	}
+	logYAML(t, Server)
+}
+
+func sampleConfig() *ServerConfig {
+	var c ServerConfig
+	c.Http.Addr = ":8080"
+	c.Grpc.Addr = ":8090"
+	r := &c.Redis.Store
+	r.Pool = 10
+	r.Addr = "localhost:6379"
+	r.Pass = "store pass"
+	r = &c.Redis.Pubsub
+	r.Pool = 20
+	r.Addr = "127.0.0.1:6379"
+	r.Pass = "pub sub pass"
+	return &c
+}
+
+func logYAML(t testing.TB, v interface{}) {
+	if testing.Verbose() {
+		t.Logf("YAML:\n%s", yamlBytes(t, v))
+	}
+}
+
+func logJSON(t testing.TB, v interface{}) {
+	if testing.Verbose() {
+		t.Logf("JSON:\n%s", jsonBytes(t, v))
+	}
+}
+
+func yamlBytes(t testing.TB, v interface{}) []byte {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func jsonBytes(t testing.TB, v interface{}) []byte {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func setArg(a ...string) {
+	if a == nil {
+		a = []string{}
+	}
+	args = a
+}

--- a/cfg/grpc.go
+++ b/cfg/grpc.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
+// GrpcConfig defines gRPC server configuration params.
+type GrpcConfig struct {
+	Addr    string `default:":9090" usage:"gRPC server |host:port| listening address"`
+	Timeout struct {
+		Connect uint `default:"120" usage:"timeout in |seconds| to establish a new connection (including HTTP/2 handshaking)"`
+	}
+	Workers uint `yaml:",omitempty" default:"0" usage:"|number| of worker goroutines that should be used to process incoming streams"`
+}
+
+// Check validates GrpcConfig params.
+func (c *GrpcConfig) Check(name ...string) (err error) {
+	if err = checkAddr(c.Addr, true, minHttpPort, name); err == nil {
+		if c.Timeout.Connect < 1 {
+			err = fmt.Errorf("%s is too small", field(append(name, "timeout", "connect")))
+		}
+	}
+	return
+}
+
+// ServerOptions returns an array of gRPC server configuration options.
+func (c *GrpcConfig) ServerOptions() []grpc.ServerOption {
+	t := c.Timeout
+	opts := []grpc.ServerOption{
+		grpc.ConnectionTimeout(usec(t.Connect)),
+		grpc.NumStreamWorkers(uint32(c.Workers)),
+	}
+	return opts
+}

--- a/cfg/help.go
+++ b/cfg/help.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"unsafe"
+)
+
+//-----------------------------------------------------------------------------
+
+func (c *ServerConfig) printHelp() {
+	if c.flags == nil {
+		return
+	}
+	c.exit = true
+	checkConfFlag := true
+	c.flags.VisitAll(func(f *flag.Flag) {
+		if checkConfFlag && f.Name == confFlag {
+			f.Usage = "config `file` path"
+			checkConfFlag = false
+			return
+		}
+		f.Usage = replByte(f.Usage, '|', '`')
+	})
+	c.flags.SetOutput(os.Stdout)
+	fmt.Println("Usage:")
+	c.flags.PrintDefaults()
+}
+
+//-----------------------------------------------------------------------------
+
+func (c *ServerConfig) printEnviron() {
+	if c.flags == nil {
+		return
+	}
+	skip := map[string]bool{envFlag: true}
+	c.exit = true
+	fmt.Println("Environment Variables:")
+	c.flags.VisitAll(func(f *flag.Flag) {
+		if skip[f.Name] {
+			return
+		}
+		name := replByte(f.Name, '.', '_')
+		name = EnvPrefix + "_" + strings.ToUpper(name)
+		if v, ok := os.LookupEnv(name); ok {
+			if envIsPassword(name) {
+				v = mockPass
+			}
+			fmt.Printf("  %s=%q\n", name, v)
+			return
+		}
+		fmt.Println(" ", name)
+	})
+}
+
+//-----------------------------------------------------------------------------
+
+func replByte(s string, from byte, to byte) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if s[i] == from {
+			if b == nil {
+				b = []byte(s)
+			}
+			b[i] = to
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+//-----------------------------------------------------------------------------
+
+func envIsPassword(name string) bool {
+	return strings.HasSuffix(name, "_PASS") ||
+		strings.HasSuffix(name, "_PASSWORD")
+}

--- a/cfg/http.go
+++ b/cfg/http.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+)
+
+const minHttpPort = 80 //nolint
+
+// HttpConfig contains HTTP server configuration params.
+type HttpConfig struct { //nolint
+	Addr string `default:":9080" usage:"HTTP server |host:port| listening address"`
+	Name string `default:"OME/1.0" usage:"HTTP server name response header"`
+	// HTTP server timeouts
+	//
+	// See: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
+	Timeout struct {
+		Idle  uint `default:"30" usage:"HTTP request idle keep-alive timeout in |seconds|"`
+		Read  uint `default:"10" usage:"HTTP request read timeout in |seconds|"`
+		Write uint `default:"10" usage:"HTTP response write timeout in |seconds|"`
+		Stop  uint `default:"20" usage:"HTTP server graceful shutdown timeout in |seconds|"`
+	}
+}
+
+// Apply sets appropriate http.Server properties.
+func (c *HttpConfig) Apply(s *http.Server) *http.Server {
+	s.Addr = c.Addr
+	s.IdleTimeout = usec(c.Timeout.Idle)
+	s.ReadTimeout = usec(c.Timeout.Read)
+	s.WriteTimeout = usec(c.Timeout.Write)
+	return s
+}
+
+// CreateServer creates and initializes new HTTP server instance.
+func (c *HttpConfig) CreateServer(ctx context.Context, mux http.Handler) *http.Server {
+	s := &http.Server{
+		Handler: mux,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+	}
+	return c.Apply(s)
+}
+
+// Shutdown attempts to gracefully shutdown http.Server waiting for
+// HttpConfig.Timeout.Stop seconds.
+//
+// Closes the http.Server immediately if HttpConfig.Timeout.Stop is zero.
+func (c *HttpConfig) Shutdown(s *http.Server) error {
+	if c.Timeout.Stop == 0 {
+		return s.Close()
+	}
+	end, cancel := context.WithDeadline(context.Background(), time.Now().Add(usec(c.Timeout.Stop)))
+	err := s.Shutdown(end)
+	cancel()
+	if err != nil && err == context.DeadlineExceeded {
+		return s.Close()
+	}
+	return err
+}
+
+// Check validates HttpConfig params.
+func (c *HttpConfig) Check(name ...string) (err error) {
+	err = checkAddr(c.Addr, true, minHttpPort, name)
+	return
+}

--- a/cfg/omesrv.yaml
+++ b/cfg/omesrv.yaml
@@ -1,0 +1,22 @@
+# OME Server Configuration
+
+http:
+  addr: :9080
+  timeout:
+    idle: 30
+    read: 10
+    write: 10
+    stop: 20
+
+grpc:
+  addr: :9090
+
+redis:
+  store:
+    pool: 10
+    addr: localhost:6379
+    pass: ""
+  pubsub:
+    pool: 10
+    addr: localhost:6379
+    pass: ""

--- a/cfg/pass.go
+++ b/cfg/pass.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+// Password is a string type with protection from plain text serialization.
+type Password string
+
+const mockPass = "****************"
+
+var (
+	zeroPass = []byte("")
+	safePass = []byte(mockPass)
+)
+
+// MarshalText function protects exposing Password as a plain text
+// in JSON/YAML/Text serialization.
+func (p Password) MarshalText() ([]byte, error) {
+	if len(p) == 0 {
+		return zeroPass, nil
+	}
+	return safePass, nil
+}
+
+// String mocks Password string from printing/formatting.
+func (p Password) String() string {
+	if len(p) > 0 {
+		return mockPass
+	}
+	return ""
+}

--- a/cfg/pass_test.go
+++ b/cfg/pass_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPassword_MarshalText(t *testing.T) {
+	data := map[Password]string{
+		"":       "\"\"\n",
+		"secret": "'****************'\n",
+	}
+	for k, v := range data {
+		y := string(yamlBytes(t, k))
+		require.Equal(t, v, y)
+	}
+}
+
+func TestPassword_String(t *testing.T) {
+	data := map[Password]string{
+		"":       "",
+		"secret": mockPass,
+	}
+	for k, v := range data {
+		s := fmt.Sprintf("%s", k) //nolint
+		require.Equal(t, v, s)
+	}
+}

--- a/cfg/path.go
+++ b/cfg/path.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//-----------------------------------------------------------------------------
+
+func configSearch(fileName string, files []string) ([]string, error) {
+	const cfgEnv = EnvPrefix + "_CONF"
+	type pathFunc = func() (string, error)
+	if cfg, ok := os.LookupEnv(cfgEnv); ok && len(cfg) > 0 {
+		files = append(files, cfg)
+	}
+	run := []pathFunc{workPath, execPath, dataPath}
+	for i := range run {
+		dir, err := run[i]()
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, filepath.Join(dir, fileName))
+	}
+	return files, nil
+}
+
+//-----------------------------------------------------------------------------
+
+func workPath() (dir string, err error) {
+	dir, err = os.Getwd()
+	if err != nil {
+		err = pathFail("os.Getwd()", err)
+	}
+	return
+}
+
+//-----------------------------------------------------------------------------
+
+func execPath() (dir string, err error) {
+	dir, err = os.Executable()
+	if err != nil {
+		err = pathFail("os.Executable()", err)
+		return
+	}
+	var inf os.FileInfo
+	inf, err = os.Lstat(dir)
+	if err != nil {
+		err = pathFail("os.Lstat", err)
+		return
+	}
+	if (inf.Mode() & os.ModeSymlink) != 0 {
+		dir, err = filepath.EvalSymlinks(dir)
+		if err != nil {
+			err = pathFail("EvalSymlinks()", err)
+			return
+		}
+	}
+	dir = filepath.Dir(dir)
+	return
+}
+
+//-----------------------------------------------------------------------------
+
+func dataPath() (dir string, err error) {
+	dir, err = os.UserConfigDir()
+	if err != nil {
+		err = pathFail("os.UserConfigDir()", err)
+		return
+	}
+	dir = filepath.Join(dir, AppName)
+	return
+}
+
+//-----------------------------------------------------------------------------
+
+func pathFail(name string, err error) error {
+	return fmt.Errorf("%s failed: %w", name, err)
+}

--- a/cfg/redis.go
+++ b/cfg/redis.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+const (
+	redisMinPool = 0
+	redisMaxPool = 1024
+	redisMinPort = 80
+)
+
+// RedisConfig wraps Redis store and pub-sub connection params.
+type RedisConfig struct {
+	Store  RedisConnect
+	Pubsub RedisConnect
+}
+
+// RedisConnect contains necessary params to connect to a Redis server.
+type RedisConnect struct {
+	Pool int      `default:"10" usage:"Redis server pool |size|"`
+	Addr string   `default:"127.0.0.1:6379" usage:"Redis server |host:port| address"`
+	Pass Password `usage:"Redis server |password|"`
+}
+
+// Check validates RedisConfig.
+func (c *RedisConfig) Check(name ...string) (err error) {
+	if err = c.Store.Check(append(name, "store")); err == nil {
+		err = c.Pubsub.Check(append(name, "pubsub"))
+	}
+	return
+}
+
+// Check validates RedisConnect.
+func (c *RedisConnect) Check(name []string) (err error) {
+	err = checkRange(c.Pool, redisMinPool, redisMaxPool, append(name, "pool"))
+	if err == nil {
+		err = checkAddr(c.Addr, false, redisMinPort, name)
+	}
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/openmarketplaceengine/openmarketplaceengine
 go 1.17
 
 require (
+	github.com/cristalhq/aconfig v0.16.8
+	github.com/cristalhq/aconfig/aconfigyaml v0.16.1
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
@@ -11,6 +13,7 @@ require (
 	go.uber.org/zap v1.20.0
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -36,6 +39,5 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,11 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cristalhq/aconfig v0.16.1/go.mod h1:NXaRp+1e6bkO4dJn+wZ71xyaihMDYPtCSvEhMTm/H3E=
+github.com/cristalhq/aconfig v0.16.8 h1:lg8i0XHgfhvsnjNM5q/ou6jIHDRXlbBybjRP9t2fWuw=
+github.com/cristalhq/aconfig v0.16.8/go.mod h1:NXaRp+1e6bkO4dJn+wZ71xyaihMDYPtCSvEhMTm/H3E=
+github.com/cristalhq/aconfig/aconfigyaml v0.16.1 h1:ghmzWFolCuja6BzBvHkNAn2Qsewu6xqdAXQyWnXjvZw=
+github.com/cristalhq/aconfig/aconfigyaml v0.16.1/go.mod h1:UgM0LkO4TKbC0s/oUP2p5POM6QiQwNvOFXostf6con0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
**Requirements:**

1. Struct-based with strong typed values
2. Validating
3. Multiple sources of config values:
   - Default values defined in struct tags
   - Configuration file in predefined and/or custom locations
   - Environment variables
   - Command line arguments
4. Basic security protecting leaking passwords
5. Minimal external dependencies

**Implementation:**

* Config file name: **omesrv.yaml**
* Config file search paths:
    * Current working directory
    * Executable directory
    * [os.UserConfigDir()](https://pkg.go.dev/os#UserConfigDir)
        * **Linux**
            * `$HOME/.config/omesrv/omesrv.yaml`
        * **macOS** 
            * `$HOME/Library/Application Support/omesrv/omesrv.yaml`
        * **Windows**
            * `%AppData%\omesrv\omesrv.yaml`
    * File path provided with `-conf` command line argument
    * File path from `OME_CONF` environment variable
    * Custom:
        * `cfg.Server.AddConfigFile(file string)`
        * `cfg.Server.AddConfigDir(dir string)`

**Access:**
```
cfg.Server // Server main config
cfg.Http   // HTTP server config alias
cfg.Grpc   // gRPC server config alias
cfg.Redis  // Redis config alias
```
**Command Line Arguments:**
```
Usage:
  -conf file
    	config file path
  -env
    	print environment variables
  -grpc.addr host:port
    	gRPC server host:port listening address (default ":9090")
  -grpc.timeout.connect seconds
    	timeout in seconds to establish a new connection (including HTTP/2 handshaking) (default "120")
  -grpc.workers number
    	number of worker goroutines that should be used to process incoming streams (default "0")
  -http.addr host:port
    	HTTP server host:port listening address (default ":9080")
  -http.name string
    	HTTP server name response header (default "OME/1.0")
  -http.timeout.idle seconds
    	HTTP request idle keep-alive timeout in seconds (default "30")
  -http.timeout.read seconds
    	HTTP request read timeout in seconds (default "10")
  -http.timeout.stop seconds
    	HTTP server graceful shutdown timeout in seconds (default "20")
  -http.timeout.write seconds
    	HTTP response write timeout in seconds (default "10")
  -redis.pubsub.addr host:port
    	Redis server host:port address (default "127.0.0.1:6379")
  -redis.pubsub.pass password
    	Redis server password
  -redis.pubsub.pool size
    	Redis server pool size (default "10")
  -redis.store.addr host:port
    	Redis server host:port address (default "127.0.0.1:6379")
  -redis.store.pass password
    	Redis server password
  -redis.store.pool size
    	Redis server pool size (default "10")
```
**Environment Variables:**
```
OME_CONF
OME_GRPC_ADDR
OME_GRPC_TIMEOUT_CONNECT
OME_GRPC_WORKERS
OME_HTTP_ADDR
OME_HTTP_NAME
OME_HTTP_TIMEOUT_IDLE
OME_HTTP_TIMEOUT_READ
OME_HTTP_TIMEOUT_STOP
OME_HTTP_TIMEOUT_WRITE
OME_REDIS_PUBSUB_ADDR
OME_REDIS_PUBSUB_PASS
OME_REDIS_PUBSUB_POOL
OME_REDIS_STORE_ADDR
OME_REDIS_STORE_PASS
OME_REDIS_STORE_POOL
```
**External Dependencies:**
```
github.com/cristalhq/aconfig
github.com/cristalhq/aconfig/aconfigyaml
gopkg.in/yaml.v2
```
Closes #29 