### PR TITLE
feat(provider-state): provider state model, FSM, initial

### DIFF
--- a/core/model/provider/state.go
+++ b/core/model/provider/state.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/cocoonspace/fsm"
+)
+
+type State int
+
+type Event int
+
+const (
+	Offline State = iota
+	Online
+	PickingUp
+	Delivering
+)
+
+func (s State) String() string {
+	return [...]string{"Offline", "Online", "PickingUp", "Delivering"}[s]
+}
+
+const (
+	GoOnline Event = iota
+	GoOffline
+	PickUp
+	Deliver
+	CompleteDelivery
+)
+
+func (s Event) String() string {
+	return [...]string{"GoOnline", "GoOffline", "PickUp", "Deliver", "CompleteDelivery"}[s]
+}
+
+type StateController struct {
+	fcm *fsm.FSM
+}
+
+func (c *StateController) GoOnline() error {
+	res := c.fcm.Event(fsm.Event(GoOnline))
+	err := c.checkState(res, GoOnline, Online)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *StateController) GoOffline() error {
+	res := c.fcm.Event(fsm.Event(GoOffline))
+	err := c.checkState(res, GoOffline, Offline)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *StateController) PickUp() error {
+	res := c.fcm.Event(fsm.Event(PickUp))
+	err := c.checkState(res, PickUp, PickingUp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *StateController) Deliver() error {
+	res := c.fcm.Event(fsm.Event(Deliver))
+	err := c.checkState(res, Deliver, Delivering)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *StateController) CompleteDelivery() error {
+	res := c.fcm.Event(fsm.Event(CompleteDelivery))
+	err := c.checkState(res, CompleteDelivery, Online)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c StateController) checkState(res bool, event Event, expected State) error {
+	current := State(c.fcm.Current())
+	if !res {
+		return fmt.Errorf("state transition failed for event=%v current=%v", event, current)
+	}
+	if current != expected {
+		return fmt.Errorf("state check failed for event=%v current=%v expected=%v", event, current, expected)
+	}
+	return nil
+}
+
+func NewStateController(initialState State) *StateController {
+	f := fsm.New(fsm.State(initialState))
+	f.Transition(fsm.On(fsm.Event(GoOnline)), fsm.Src(fsm.State(Offline)), fsm.Dst(fsm.State(Online)))
+	f.Transition(fsm.On(fsm.Event(GoOffline)), fsm.Src(fsm.State(Online)), fsm.Dst(fsm.State(Offline)))
+	f.Transition(fsm.On(fsm.Event(PickUp)), fsm.Src(fsm.State(Online)), fsm.Dst(fsm.State(PickingUp)))
+	f.Transition(fsm.On(fsm.Event(Deliver)), fsm.Src(fsm.State(PickingUp)), fsm.Dst(fsm.State(Delivering)))
+	f.Transition(fsm.On(fsm.Event(CompleteDelivery)), fsm.Src(fsm.State(Delivering)), fsm.Dst(fsm.State(Online)))
+
+	f.EnterState(fsm.State(Offline), func() {
+		fmt.Println("going offline")
+	})
+	f.Enter(func(state fsm.State) {
+		fmt.Printf("enter state=%v\n", State(state))
+	})
+	f.Exit(func(state fsm.State) {
+		fmt.Printf("exit state=%v\n", State(state))
+	})
+
+	return &StateController{fcm: f}
+}

--- a/core/model/provider/state.go
+++ b/core/model/provider/state.go
@@ -39,47 +39,27 @@ type StateController struct {
 
 func (c *StateController) GoOnline() error {
 	res := c.fcm.Event(fsm.Event(GoOnline))
-	err := c.checkState(res, GoOnline, Online)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.checkState(res, GoOnline, Online)
 }
 
 func (c *StateController) GoOffline() error {
 	res := c.fcm.Event(fsm.Event(GoOffline))
-	err := c.checkState(res, GoOffline, Offline)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.checkState(res, GoOffline, Offline)
 }
 
 func (c *StateController) PickUp() error {
 	res := c.fcm.Event(fsm.Event(PickUp))
-	err := c.checkState(res, PickUp, PickingUp)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.checkState(res, PickUp, PickingUp)
 }
 
 func (c *StateController) Deliver() error {
 	res := c.fcm.Event(fsm.Event(Deliver))
-	err := c.checkState(res, Deliver, Delivering)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.checkState(res, Deliver, Delivering)
 }
 
 func (c *StateController) CompleteDelivery() error {
 	res := c.fcm.Event(fsm.Event(CompleteDelivery))
-	err := c.checkState(res, CompleteDelivery, Online)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.checkState(res, CompleteDelivery, Online)
 }
 
 func (c StateController) checkState(res bool, event Event, expected State) error {

--- a/core/model/provider/state_test.go
+++ b/core/model/provider/state_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderState(t *testing.T) {
+	state := NewStateController(Offline)
+
+	t.Run("testGoOnline", func(t *testing.T) {
+		testGoOnline(t, state)
+	})
+
+	t.Run("testGoOffline", func(t *testing.T) {
+		testGoOffline(t, state)
+	})
+
+	t.Run("testInitialState", func(t *testing.T) {
+		testInitialState(t)
+	})
+
+	t.Run("testAllTransitions", func(t *testing.T) {
+		testAllTransitions(t, state)
+	})
+}
+
+func testGoOnline(t *testing.T, state *StateController) {
+	state.fcm.Reset()
+	err := state.GoOnline()
+	require.NoError(t, err)
+	require.Equal(t, Online, State(state.fcm.Current()))
+
+	err = state.GoOnline()
+	assert.Error(t, err)
+}
+
+func testGoOffline(t *testing.T, state *StateController) {
+	state.fcm.Reset()
+	err := state.GoOffline()
+	require.Error(t, err)
+	require.Equal(t, Offline, State(state.fcm.Current()))
+
+	err = state.GoOnline()
+	assert.NoError(t, err)
+
+	err = state.GoOffline()
+	require.NoError(t, err)
+}
+
+func testInitialState(t *testing.T) {
+	state := NewStateController(Delivering)
+	err := state.GoOffline()
+	require.Error(t, err)
+	require.Equal(t, Delivering, State(state.fcm.Current()))
+
+	err = state.CompleteDelivery()
+	assert.NoError(t, err)
+	require.Equal(t, Online, State(state.fcm.Current()))
+}
+
+func testAllTransitions(t *testing.T, state *StateController) {
+	state.fcm.Reset()
+	err := state.GoOnline()
+	assert.NoError(t, err)
+	require.Equal(t, Online, State(state.fcm.Current()))
+
+	err = state.PickUp()
+	require.NoError(t, err)
+	require.Equal(t, PickingUp, State(state.fcm.Current()))
+
+	err = state.Deliver()
+	require.NoError(t, err)
+	require.Equal(t, Delivering, State(state.fcm.Current()))
+
+	err = state.CompleteDelivery()
+	require.NoError(t, err)
+	require.Equal(t, Online, State(state.fcm.Current()))
+
+	err = state.GoOffline()
+	require.NoError(t, err)
+	require.Equal(t, Offline, State(state.fcm.Current()))
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openmarketplaceengine/openmarketplaceengine
 go 1.17
 
 require (
+	github.com/cocoonspace/fsm v1.0.1
 	github.com/cristalhq/aconfig v0.16.8
 	github.com/cristalhq/aconfig/aconfigyaml v0.16.1
 	github.com/go-redis/redis/v8 v8.11.4

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cristalhq/aconfig v0.16.8 h1:lg8i0XHgfhvsnjNM5q/ou6jIHDRXlbBybjRP9t2f
 github.com/cristalhq/aconfig v0.16.8/go.mod h1:NXaRp+1e6bkO4dJn+wZ71xyaihMDYPtCSvEhMTm/H3E=
 github.com/cristalhq/aconfig/aconfigyaml v0.16.1 h1:ghmzWFolCuja6BzBvHkNAn2Qsewu6xqdAXQyWnXjvZw=
 github.com/cristalhq/aconfig/aconfigyaml v0.16.1/go.mod h1:UgM0LkO4TKbC0s/oUP2p5POM6QiQwNvOFXostf6con0=
+github.com/cocoonspace/fsm v1.0.1 h1:dPjDYJh1XL7r8jERbAVFrk7kLzTOaRgx9EBoS9fV6PA=
+github.com/cocoonspace/fsm v1.0.1/go.mod h1:2NILMnDanocMM88qdqAzyq9Q1DwCjXqAIGtbhdXFC0Q=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
dependency on simple finite-state-machines (FSM) library for managing state transitions.
the "Provider" states here are but example, and subject to change.

Overall, seems we can use this approach to model and guard state transitions. Each transition can be supplied with hook function carrying business logic. state can be persisted and restored from database, and resumed. (persistence is a todo) 
 
