### PR TITLE
feat(jdl): itinerary job, and steps states

### DIFF
--- a/core/model/job/itinerary/flow.go
+++ b/core/model/job/itinerary/flow.go
@@ -1,0 +1,89 @@
+package itinerary
+
+import "fmt"
+
+type StepType int
+
+const (
+	goToLocation StepType = iota
+	pickUpPassengers
+	dropOffPassengers
+)
+
+type step struct {
+	prev     *step
+	next     *step
+	id       string
+	stepType StepType
+}
+
+type flow struct {
+	head *step
+	tail *step
+}
+
+func newFlow() *flow {
+	return &flow{}
+}
+
+func (f *flow) addStep(stepID string, stepType StepType) {
+	s := &step{
+		next:     f.head,
+		id:       stepID,
+		stepType: stepType,
+	}
+	if f.head != nil {
+		f.head.prev = s
+	}
+	f.head = s
+
+	l := f.head
+	for l.next != nil {
+		l = l.next
+	}
+	f.tail = l
+}
+
+func (f *flow) addStepBefore(beforeID string, stepID string, stepType StepType) error {
+	s := &step{
+		id:       stepID,
+		stepType: stepType,
+	}
+
+	if f.head == nil {
+		return fmt.Errorf("flow has no steps")
+	}
+	start := f.head
+	for start != nil {
+		if start.id == beforeID {
+			s.prev = start
+			s.next = start.next
+			start.next = s
+		}
+		start = start.next
+	}
+	f.tail = start
+	return nil
+}
+
+func (f *flow) removeStep(stepID string) {
+	step := f.head
+	for step != nil {
+		if step.id == stepID {
+			step.prev.next = step.next
+			step.next.prev = step.prev
+		}
+		step = step.next
+	}
+
+	f.tail = step
+}
+
+func (f *flow) dump() {
+	step := f.head
+	for step != nil {
+		fmt.Printf("%+v ->", step.id)
+		step = step.next
+	}
+	fmt.Println()
+}

--- a/core/model/job/itinerary/flow_test.go
+++ b/core/model/job/itinerary/flow_test.go
@@ -1,0 +1,13 @@
+package itinerary
+
+import "testing"
+
+func TestFlow(t *testing.T) {
+	f := newFlow()
+
+	f.addStep("step1", goToLocation)
+	f.addStep("step2", pickUpPassengers)
+	f.addStep("step3", dropOffPassengers)
+
+	f.removeStep("step2")
+}

--- a/core/model/job/itinerary/itinerary.go
+++ b/core/model/job/itinerary/itinerary.go
@@ -1,0 +1,26 @@
+package itinerary
+
+type Stepf func()
+
+type Passenger struct {
+	ID   string
+	Name string
+}
+
+type Itinerary struct {
+	ID        string
+	StartTime string
+	flow      *flow
+}
+
+func (i *Itinerary) AddGoToLocationStep() {
+	i.flow.addStep("abc", goToLocation)
+}
+
+func NewItinerary(id string, startTime string) *Itinerary {
+	return &Itinerary{
+		ID:        id,
+		StartTime: startTime,
+		flow:      newFlow(),
+	}
+}

--- a/core/model/job/itinerary/itinerary_test.go
+++ b/core/model/job/itinerary/itinerary_test.go
@@ -1,0 +1,13 @@
+package itinerary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItinerary(t *testing.T) {
+	itinerary := NewItinerary("i-1", "immediate")
+
+	require.NotNil(t, itinerary)
+}

--- a/core/model/job/step/dropoff/dropoff.go
+++ b/core/model/job/step/dropoff/dropoff.go
@@ -1,0 +1,38 @@
+package dropoff
+
+import (
+	"github.com/cocoonspace/fsm"
+)
+
+const (
+	ReadyEvent fsm.Event = iota
+	CompletedEvent
+)
+
+const (
+	ReadyState fsm.State = iota
+	CompletedState
+)
+
+type DropOff struct {
+	f *fsm.FSM
+}
+
+func (p *DropOff) Complete() {
+	p.f.Event(CompletedEvent)
+}
+
+func NewDropOff(onExit func()) *DropOff {
+	return &DropOff{
+		f: newDropOffFsm(onExit),
+	}
+}
+
+func newDropOffFsm(onExit func()) *fsm.FSM {
+	f := fsm.New(ReadyState)
+	f.Transition(fsm.On(CompletedEvent), fsm.Src(ReadyState), fsm.Dst(CompletedState))
+	f.Exit(func(state fsm.State) {
+		onExit()
+	})
+	return f
+}

--- a/core/model/job/step/dropoff/dropoff_test.go
+++ b/core/model/job/step/dropoff/dropoff_test.go
@@ -1,0 +1,18 @@
+package dropoff
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropOff(t *testing.T) {
+	sync := make(chan string)
+	onExit := func() {
+		sync <- "done"
+	}
+	dropOff := NewDropOff(onExit)
+
+	go dropOff.Complete()
+	require.Equal(t, "done", <-sync)
+}

--- a/core/model/job/step/gotolocation/gotolocation.go
+++ b/core/model/job/step/gotolocation/gotolocation.go
@@ -1,0 +1,68 @@
+package gotolocation
+
+import (
+	"github.com/cocoonspace/fsm"
+)
+
+type Location struct {
+	Latitude  float64
+	Longitude float64
+}
+
+const (
+	TravelingEvent fsm.Event = iota
+	NearDestinationEvent
+	AtDestinationEvent
+	CompletedEvent
+	CanceledEvent
+)
+
+const (
+	TravelingState fsm.State = iota
+	NearDestinationState
+	AtDestinationState
+	CompletedState
+	CanceledState
+)
+
+type GoToLocation struct {
+	f *fsm.FSM
+}
+
+func (p *GoToLocation) Traveling() {
+	p.f.Event(TravelingEvent)
+}
+
+func (p *GoToLocation) NearDestination() {
+	p.f.Event(NearDestinationEvent)
+}
+
+func (p *GoToLocation) AtDestination() {
+	p.f.Event(AtDestinationEvent)
+}
+
+func (p *GoToLocation) Complete() {
+	p.f.Event(CompletedEvent)
+}
+
+func (p *GoToLocation) Cancel() {
+	p.f.Event(CanceledEvent)
+}
+
+func NewGoToLocation(onExit func()) *GoToLocation {
+	return &GoToLocation{
+		f: newGoToLocationFsm(onExit),
+	}
+}
+
+func newGoToLocationFsm(onExit func()) *fsm.FSM {
+	f := fsm.New(TravelingState)
+	f.Transition(fsm.On(NearDestinationEvent), fsm.Src(TravelingState), fsm.Dst(NearDestinationState))
+	f.Transition(fsm.On(AtDestinationEvent), fsm.Src(NearDestinationState), fsm.Dst(AtDestinationState))
+	f.Transition(fsm.On(CompletedEvent), fsm.Src(AtDestinationState), fsm.Dst(CompletedState))
+	f.Transition(fsm.On(CanceledEvent), fsm.Src(AtDestinationState), fsm.Dst(CanceledState))
+	f.Exit(func(state fsm.State) {
+		onExit()
+	})
+	return f
+}

--- a/core/model/job/step/gotolocation/gotolocation_test.go
+++ b/core/model/job/step/gotolocation/gotolocation_test.go
@@ -1,0 +1,23 @@
+package gotolocation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoToLocation(t *testing.T) {
+	sync := make(chan string)
+	onExit := func() {
+		sync <- "done"
+	}
+	goToLocation := NewGoToLocation(onExit)
+
+	go func() {
+		goToLocation.Traveling()
+		goToLocation.NearDestination()
+		goToLocation.AtDestination()
+		goToLocation.Complete()
+	}()
+	require.Equal(t, "done", <-sync)
+}

--- a/core/model/job/step/pickup/pickup.go
+++ b/core/model/job/step/pickup/pickup.go
@@ -1,0 +1,38 @@
+package pickup
+
+import (
+	"github.com/cocoonspace/fsm"
+)
+
+const (
+	ReadyEvent fsm.Event = iota
+	CompletedEvent
+)
+
+const (
+	ReadyState fsm.State = iota
+	CompletedState
+)
+
+type Pickup struct {
+	f *fsm.FSM
+}
+
+func (p *Pickup) Complete() {
+	p.f.Event(CompletedEvent)
+}
+
+func NewPickup(onExit func()) *Pickup {
+	return &Pickup{
+		f: newPickUpFsm(onExit),
+	}
+}
+
+func newPickUpFsm(onExit func()) *fsm.FSM {
+	f := fsm.New(ReadyState)
+	f.Transition(fsm.On(CompletedEvent), fsm.Src(ReadyState), fsm.Dst(CompletedState))
+	f.Exit(func(state fsm.State) {
+		onExit()
+	})
+	return f
+}

--- a/core/model/job/step/pickup/pickup_test.go
+++ b/core/model/job/step/pickup/pickup_test.go
@@ -1,0 +1,18 @@
+package pickup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickUp(t *testing.T) {
+	sync := make(chan string)
+	onExit := func() {
+		sync <- "done"
+	}
+	pickup := NewPickup(onExit)
+
+	go pickup.Complete()
+	require.Equal(t, "done", <-sync)
+}


### PR DESCRIPTION
this is DRAFT PR

JDL initial implementation

1. Itinerary individual steps lay nicely on finite states, and can be modelled as state machines (FSM).
2. itinerary flow itself is dynamic, and looks more like a workflow in a sense that it is not event driven, but next step is driven by completion of previous step. hence workflow-like.


NB! the flow draft implementation assumes itinerary job step are sequential in execution. 