### PR TITLE
Add Server Lifecycle Management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . ./
 
-RUN go build -o /app/omesrv
+RUN go build -trimpath -ldflags="-s -w" -o /app/omesrv
 
 
 FROM alpine:latest
@@ -22,6 +22,6 @@ ENV OME_REDIS_STORE_POOL=$OME_REDIS_STORE_POOL
 ENV OME_REDIS_STORE_ADDR=$OME_REDIS_STORE_ADDR
 ENV OME_REDIS_STORE_PASS=$OME_REDIS_STORE_PASS
 
-EXPOSE 9080
+EXPOSE 8080
 
 CMD [ "/app/omesrv" ]

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ nuke: clean ## Clean with -modcache
 build: echo-env prepare ## Build binary
 	@echo "==> Build"
 	GOOS=linux
-	go build -a -o $(BUILD_PATH)/app ./
+	go build -a -trimpath -ldflags="-s -w" -o $(BUILD_PATH)/app ./
 
 PACKAGES=$(shell go list ./...)
 PACKAGES_WITH_TESTS = $(shell go list -f '{{if len .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... \

--- a/cfg/boot.go
+++ b/cfg/boot.go
@@ -1,0 +1,200 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+// BootFunc is an aliases for boot function.
+type BootFunc = func() error
+
+// Bootable interface describes a generic named service
+// with support for Boot/Stop lifecycle.
+type Bootable interface {
+	Boot() error
+	Stop() error
+}
+
+type BootStep uint
+
+// bootCall struct holds information about a bootable service.
+type bootCall struct {
+	// name identifies boot call for debug/error reporting
+	name string
+	// boot called when starting services
+	boot BootFunc
+	// stop called when stopping services
+	stop BootFunc
+	// step holds current boot phase
+	step BootStep
+}
+
+const (
+	stepNone = iota
+	stepBoot
+	stepStop
+	stepFail
+)
+
+// BootList holds an array of Bootable services.
+type BootList struct {
+	lock   sync.Mutex
+	call   []*bootCall
+	step   BootStep
+	Debugf PrintFunc
+	Errorf PrintFunc
+}
+
+// Use appends a Bootable object to the list.
+func (b *BootList) Use(name string, boot Bootable) *BootList {
+	if boot == nil {
+		panic("Bootable object argument is nil")
+	}
+	if len(name) == 0 {
+		name = reflect.TypeOf(boot).String()
+	}
+	return b.Add(name, boot.Boot, boot.Stop)
+}
+
+// Add appends boot functions the list.
+func (b *BootList) Add(name string, boot BootFunc, stop BootFunc) *BootList {
+	if len(name) == 0 {
+		panic("empty name argument")
+	}
+	if boot == nil && stop == nil {
+		panic("both boot and stop functions are nil")
+	}
+	if b.call == nil {
+		b.call = make([]*bootCall, 0, 8)
+	}
+	c := &bootCall{name: name, boot: boot, stop: stop}
+	b.call = append(b.call, c)
+	return b
+}
+
+// SetLog assigns Debug/Error print functions.
+func (b *BootList) SetLog(debugf, errorf PrintFunc) {
+	b.Debugf = debugf
+	b.Errorf = errorf
+}
+
+// Boot starts boot sequence.
+func (b *BootList) Boot() (err error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if b.step != stepNone {
+		err = fmt.Errorf("cannot boot with unexpected state: %q", b.step)
+		return
+	}
+	b.step = stepBoot
+	for i := 0; i < len(b.call); i++ {
+		c := b.call[i]
+		if c.boot != nil {
+			b.debugf("BOOT %s", c.name)
+			if err := c.boot(); err != nil {
+				err = &BootError{stepBoot, c.name, err}
+				c.step = stepFail
+				b.debugf("BOOT aborting...")
+				_ = b.stop(i + 1)
+				return err
+			}
+		}
+		c.step = stepBoot
+	}
+	return
+}
+
+// Stop stops boot sequence.
+func (b *BootList) Stop() (err error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if b.step != stepBoot {
+		err = fmt.Errorf("cannot stop with unexpected state: %q", b.step)
+		b.errorf("%s", err)
+		return
+	}
+	b.step = stepStop
+	err = b.stop(len(b.call))
+	if err != nil {
+		b.step = stepFail
+	}
+	return
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *BootList) stop(downFrom int) error {
+	var mulerr MultiError
+	for i := downFrom; i > 0; i-- {
+		c := b.call[i-1]
+		if c.step != stepBoot {
+			continue
+		}
+		if c.stop != nil {
+			b.debugf("STOP %s", c.name)
+			if err := c.stop(); err != nil {
+				err = mulerr.Add(&BootError{stepStop, c.name, err})
+				b.errorf("%s", err)
+				c.step = stepFail
+				continue
+			}
+		}
+		c.step = stepStop
+	}
+	return mulerr.Return()
+}
+
+//-----------------------------------------------------------------------------
+// Logging
+//-----------------------------------------------------------------------------
+
+func (b *BootList) debugf(format string, args ...interface{}) {
+	if b.Debugf != nil {
+		b.Debugf(format, args...)
+	}
+}
+
+func (b *BootList) errorf(format string, args ...interface{}) { //nolint
+	if b.Errorf != nil {
+		b.Errorf(format, args...)
+	}
+}
+
+//-----------------------------------------------------------------------------
+// boot step
+//-----------------------------------------------------------------------------
+
+func (s BootStep) String() string {
+	switch s {
+	case stepNone:
+		return "NONE"
+	case stepBoot:
+		return "BOOT"
+	case stepStop:
+		return "STOP"
+	case stepFail:
+		return "FAIL"
+	}
+	return "<invalid step>"
+}
+
+//-----------------------------------------------------------------------------
+
+type BootError struct {
+	Step BootStep
+	Name string
+	Err  error
+}
+
+func (e *BootError) Error() string {
+	return fmt.Sprintf("%s %s: %s", e.Step, e.Name, e.Err)
+}
+
+func (e *BootError) Unwrap() error {
+	return e.Err
+}

--- a/cfg/boot_test.go
+++ b/cfg/boot_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootList_Boot(t *testing.T) {
+	b := testBoot(t)
+	addBoot(b, "DBMS", false, false)
+	addBoot(b, "GRPC", false, false)
+	addBoot(b, "HTTP", false, false)
+	require.NoError(t, b.Boot())
+	require.NoError(t, b.Stop())
+}
+
+func TestBootList_Error(t *testing.T) {
+	b := testBoot(t)
+	addBoot(b, "DBMS", false, false)
+	addBoot(b, "GRPC", false, false)
+	addBoot(b, "HTTP", true, false)
+	require.Error(t, b.Boot())
+}
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+func addBoot(b *BootList, name string, failBoot bool, failStop bool) { //nolint
+	b.Add(name, testBootFunc(failBoot), testBootFunc(failStop))
+}
+
+//-----------------------------------------------------------------------------
+
+func testBootFunc(fail bool) BootFunc {
+	return func() error {
+		if fail {
+			return fmt.Errorf("requested test error: %d", byte(rand.Uint32()))
+		}
+		return nil
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+func testBoot(t testing.TB) *BootList {
+	b := new(BootList)
+	if testing.Verbose() {
+		b.Debugf = testPrintFunc(t, "DEBUG")
+		b.Errorf = testPrintFunc(t, "ERROR")
+	}
+	return b
+}
+
+//-----------------------------------------------------------------------------
+
+func testPrintFunc(t testing.TB, level string) PrintFunc {
+	const timeFormat = "15:04:05.000"
+	return func(format string, args ...interface{}) {
+		t.Helper()
+		t.Logf("%s [%s] %s", time.Now().Format(timeFormat), level, fmt.Sprintf(format, args...))
+	}
+}

--- a/cfg/conf_test.go
+++ b/cfg/conf_test.go
@@ -22,8 +22,8 @@ func TestServerConfig_Load(t *testing.T) {
 //-----------------------------------------------------------------------------
 
 func TestServerConfig_LoadEnv(t *testing.T) {
-	t.Setenv("OME_HTTP_ADDR", ":80")
-	t.Setenv("OME_GRPC_ADDR", ":90")
+	t.Setenv("OME_HTTP_PORT", "80")
+	t.Setenv("OME_GRPC_PORT", "90")
 	t.Setenv("OME_REDIS_STORE_POOL", "32")
 	t.Setenv("OME_REDIS_STORE_PASS", "SECRET")
 	loadConfig(t)
@@ -32,7 +32,7 @@ func TestServerConfig_LoadEnv(t *testing.T) {
 //-----------------------------------------------------------------------------
 
 func TestServerConfig_LoadArg(t *testing.T) {
-	setArg("-http.addr", ":100", "-grpc.addr", ":110", "-redis.store.pass", "secret")
+	setArg("-http.port", "100", "-grpc.port", "110", "-redis.store.pass", "secret")
 	loadConfig(t)
 }
 
@@ -101,8 +101,8 @@ func loadConfig(t testing.TB) {
 
 func sampleConfig() *ServerConfig {
 	var c ServerConfig
-	c.Http.Addr = ":8080"
-	c.Grpc.Addr = ":8090"
+	c.Http.Port = 8080
+	c.Grpc.Port = 8090
 	r := &c.Redis.Store
 	r.Pool = 10
 	r.Addr = "localhost:6379"

--- a/cfg/error.go
+++ b/cfg/error.go
@@ -1,0 +1,78 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MultiError struct {
+	err []error
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) Add(err error) error {
+	if err != nil {
+		e.err = append(e.err, err)
+	}
+	return err
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) Formatf(format string, args ...interface{}) error {
+	return e.Add(fmt.Errorf(format, args...))
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) WithLast(f func(err error) error) error {
+	if n := len(e.err) - 1; n >= 0 {
+		e.err[n] = f(e.err[n])
+		return e.err[n]
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) Last() error {
+	if n := len(e.err); n > 0 {
+		return e.err[n-1]
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) Error() string {
+	n := len(e.err)
+	if n == 0 {
+		return "<empty error>"
+	}
+	if n == 1 {
+		return e.err[0].Error()
+	}
+	var b strings.Builder
+	b.Grow(n * 32)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(e.err[i].Error())
+	}
+	return b.String()
+}
+
+//-----------------------------------------------------------------------------
+
+func (e *MultiError) Return() error {
+	if len(e.err) > 0 {
+		return e
+	}
+	return nil
+}

--- a/cfg/grpc.go
+++ b/cfg/grpc.go
@@ -6,22 +6,23 @@ package cfg
 
 import (
 	"fmt"
-
-	"google.golang.org/grpc"
+	"time"
 )
 
 // GrpcConfig defines gRPC server configuration params.
 type GrpcConfig struct {
-	Addr    string `default:":9090" usage:"gRPC server |host:port| listening address"`
+	Bind    string `default:"0.0.0.0" usage:"gRPC server local bind #address#"`
+	Port    int    `default:"8090" usage:"gRPC server #port#"`
 	Timeout struct {
-		Connect uint `default:"120" usage:"timeout in |seconds| to establish a new connection (including HTTP/2 handshaking)"`
+		Connect uint `default:"120" usage:"timeout in #seconds# to establish a new connection (including HTTP/2 handshaking)"`
+		Stop    uint `default:"20" usage:"gRPC server graceful shutdown timeout in #seconds#"`
 	}
-	Workers uint `yaml:",omitempty" default:"0" usage:"|number| of worker goroutines that should be used to process incoming streams"`
+	Workers uint `yaml:",omitempty" default:"0" usage:"#number# of worker goroutines that should be used to process incoming streams"`
 }
 
 // Check validates GrpcConfig params.
 func (c *GrpcConfig) Check(name ...string) (err error) {
-	if err = checkAddr(c.Addr, true, minHttpPort, name); err == nil {
+	if err = checkPort(c.Port, minHttpPort, append(name, "port")); err == nil {
 		if c.Timeout.Connect < 1 {
 			err = fmt.Errorf("%s is too small", field(append(name, "timeout", "connect")))
 		}
@@ -29,12 +30,18 @@ func (c *GrpcConfig) Check(name ...string) (err error) {
 	return
 }
 
-// ServerOptions returns an array of gRPC server configuration options.
-func (c *GrpcConfig) ServerOptions() []grpc.ServerOption {
-	t := c.Timeout
-	opts := []grpc.ServerOption{
-		grpc.ConnectionTimeout(usec(t.Connect)),
-		grpc.NumStreamWorkers(uint32(c.Workers)),
-	}
-	return opts
+func (c *GrpcConfig) Addr() string {
+	return fmt.Sprintf("%s:%d", c.Bind, c.Port)
+}
+
+func (c *GrpcConfig) ConnectTimeout() time.Duration {
+	return usec(c.Timeout.Connect)
+}
+
+func (c *GrpcConfig) StopTimeout() time.Duration {
+	return usec(c.Timeout.Stop)
+}
+
+func (c *GrpcConfig) StreamWorkers() uint32 {
+	return uint32(c.Workers)
 }

--- a/cfg/log.go
+++ b/cfg/log.go
@@ -8,16 +8,26 @@ import (
 	"fmt"
 )
 
+type PrintFunc = func(format string, args ...interface{})
+
+// Logger is a basic subset of logging functions used in this package.
+type Logger interface {
+	IsDebug() bool
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
 // LogConfig contains logging configuration params.
 type LogConfig struct {
-	Level  string `default:"info" usage:"log |level|: [debug, info, warn, error, panic, fatal]"`
-	Style  string `default:"plain" usage:"log format |style|: [plain, json]"`
-	Term   string `default:"stdout" usage:"log standard output name: |[stdout, stderr, null]|"`
-	File   string `usage:"log file |path|"`
-	Trim   bool   `default:"false" usage:"|enable| trimming of the log file on start"`
-	Trace  bool   `default:"false" usage:"|enable| logging error stack traces"`
-	Devel  bool   `default:"false" usage:"|enable| developer's mode"`
-	Caller bool   `default:"false" usage:"|enable| logging the caller function name"`
+	Level  string `default:"info" usage:"log #level#: [debug|info|warn|error|panic|fatal]"`
+	Style  string `default:"plain" usage:"log format #style#: [plain|json]"`
+	Term   string `default:"stdout" usage:"log standard output name: #[stdout|stderr|null]#"`
+	File   string `usage:"log file #path#"`
+	Trim   bool   `default:"false" usage:"#enable# trimming of the log file on start"`
+	Trace  bool   `default:"false" usage:"#enable# logging error stack traces"`
+	Devel  bool   `default:"false" usage:"#enable# developer's mode"`
+	Caller bool   `default:"false" usage:"#enable# logging the caller function name"`
 }
 
 // Check validates LogConfig params.

--- a/cfg/omesrv.yaml
+++ b/cfg/omesrv.yaml
@@ -1,7 +1,7 @@
 # OME Server Configuration
 
 http:
-  addr: :9080
+  port: 8080
   timeout:
     idle: 30
     read: 10
@@ -9,7 +9,7 @@ http:
     stop: 20
 
 grpc:
-  addr: :9090
+  port: 8090
 
 redis:
   store:

--- a/cfg/redis.go
+++ b/cfg/redis.go
@@ -18,9 +18,9 @@ type RedisConfig struct {
 
 // RedisConnect contains necessary params to connect to a Redis server.
 type RedisConnect struct {
-	Pool int      `default:"10" usage:"Redis server pool |size|"`
-	Addr string   `default:"127.0.0.1:6379" usage:"Redis server |host:port| address"`
-	Pass Password `usage:"Redis server |password|"`
+	Pool int      `default:"10" usage:"Redis server pool #size#"`
+	Addr string   `default:"127.0.0.1:6379" usage:"Redis server #host:port# address"`
+	Pass Password `usage:"Redis server #password#"`
 }
 
 // Check validates RedisConfig.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cocoonspace/fsm v1.0.1
 	github.com/cristalhq/aconfig v0.16.8
 	github.com/cristalhq/aconfig/aconfigyaml v0.16.1
+	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
+github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F46Tg=
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
@@ -115,8 +117,6 @@ go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/zap v1.20.0 h1:N4oPlghZwYG55MlU6LXk/Zp00FVNE9X9wrYO8CEs4lc=
-go.uber.org/zap v1.20.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/log/log.go
+++ b/log/log.go
@@ -1,43 +1,72 @@
 package log
 
+// Logger interface describes logging functions.
+type Logger interface {
+	IsDebug() bool
+	IsInfo() bool
+	IsWarn() bool
+	IsError() bool
+	IsLevel(lev Level) bool
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Sync() error
+}
+
+// Log returns default Logger implementation.
+func Log() Logger {
+	return &z
+}
+
 //-----------------------------------------------------------------------------
 
+func IsLevel(level Level) bool {
+	return z.IsLevel(level)
+}
+
 func IsDebug() bool {
-	return z.Core().Enabled(LevelDebug)
+	return z.IsDebug()
 }
 
 func IsInfo() bool {
-	return z.Core().Enabled(LevelInfo)
+	return z.IsInfo()
 }
 
 func IsWarn() bool {
-	return z.Core().Enabled(LevelWarn)
+	return z.IsWarn()
 }
 
 func IsError() bool {
-	return z.Core().Enabled(LevelError)
+	return z.IsError()
 }
 
 //-----------------------------------------------------------------------------
 
 func Debugf(format string, args ...interface{}) {
-	s.Debugf(format, args...)
+	z.Debugf(format, args...)
 }
 
 func Infof(format string, args ...interface{}) {
-	s.Infof(format, args...)
+	z.Infof(format, args...)
 }
 
 func Warnf(format string, args ...interface{}) {
-	s.Warnf(format, args...)
+	z.Warnf(format, args...)
 }
 
 func Errorf(format string, args ...interface{}) {
-	s.Errorf(format, args...)
+	z.Errorf(format, args...)
+}
+
+func Panicf(format string, args ...interface{}) {
+	z.Panicf(format, args...)
 }
 
 func Fatalf(format string, args ...interface{}) {
-	s.Fatalf(format, args...)
+	z.Fatalf(format, args...)
 }
 
 //-----------------------------------------------------------------------------
@@ -48,4 +77,60 @@ func Sync() error {
 
 func SafeSync() {
 	_ = z.Sync()
+}
+
+//-----------------------------------------------------------------------------
+// Zap Log
+//-----------------------------------------------------------------------------
+
+func (z *zapLog) IsLevel(level Level) bool {
+	return z.c.Enabled(level)
+}
+
+func (z *zapLog) IsDebug() bool {
+	return z.c.Enabled(LevelDebug)
+}
+
+func (z *zapLog) IsInfo() bool {
+	return z.c.Enabled(LevelInfo)
+}
+
+func (z *zapLog) IsWarn() bool {
+	return z.c.Enabled(LevelWarn)
+}
+
+func (z *zapLog) IsError() bool {
+	return z.c.Enabled(LevelError)
+}
+
+//-----------------------------------------------------------------------------
+
+func (z *zapLog) Debugf(format string, args ...interface{}) {
+	z.s.Debugf(format, args...)
+}
+
+func (z *zapLog) Infof(format string, args ...interface{}) {
+	z.s.Infof(format, args...)
+}
+
+func (z *zapLog) Warnf(format string, args ...interface{}) {
+	z.s.Warnf(format, args...)
+}
+
+func (z *zapLog) Errorf(format string, args ...interface{}) {
+	z.s.Errorf(format, args...)
+}
+
+func (z *zapLog) Panicf(format string, args ...interface{}) {
+	z.s.Panicf(format, args...)
+}
+
+func (z *zapLog) Fatalf(format string, args ...interface{}) {
+	z.s.Fatalf(format, args...)
+}
+
+//-----------------------------------------------------------------------------
+
+func (z *zapLog) Sync() error {
+	return z.z.Sync()
 }

--- a/srv/htp/http.go
+++ b/srv/htp/http.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openmarketplaceengine/openmarketplaceengine/log"
 )
 
-type HttpServer struct {
+type HttpServer struct { //nolint
 	chi.Router
 	lsn net.Listener
 	srv *http.Server
@@ -25,7 +25,7 @@ type HttpServer struct {
 
 //-----------------------------------------------------------------------------
 
-func NewHttpServer() *HttpServer {
+func NewHttpServer() *HttpServer { //nolint
 	s := new(HttpServer)
 	s.Router = chi.NewMux()
 	return s

--- a/srv/htp/http.go
+++ b/srv/htp/http.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package htp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/openmarketplaceengine/openmarketplaceengine/cfg"
+	"github.com/openmarketplaceengine/openmarketplaceengine/log"
+)
+
+type HttpServer struct {
+	chi.Router
+	lsn net.Listener
+	srv *http.Server
+}
+
+//-----------------------------------------------------------------------------
+
+func NewHttpServer() *HttpServer {
+	s := new(HttpServer)
+	s.Router = chi.NewMux()
+	return s
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *HttpServer) Boot() (err error) {
+	c := cfg.Http
+	addr := c.Addr()
+	s.lsn, err = net.Listen("tcp", addr)
+	if err != nil {
+		return
+	}
+	log.Infof("HTTP listening on %s", addr)
+	ctx := cfg.Context()
+	s.srv = &http.Server{
+		Addr: addr,
+		BaseContext: func(_ net.Listener) context.Context {
+			return ctx
+		},
+		ErrorLog:     log.NewStdLog(log.LevelError),
+		Handler:      s.Router,
+		IdleTimeout:  c.IdleTimeout(),
+		ReadTimeout:  c.ReadTimeout(),
+		WriteTimeout: c.WriteTimeout(),
+	}
+	s.srv.RegisterOnShutdown(func() {
+		log.Infof("HTTP server shutdown")
+	})
+	go s.serve()
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *HttpServer) Stop() error {
+	if s.srv == nil {
+		return fmt.Errorf("HTTP server not initialized")
+	}
+	wait := cfg.Http.StopTimeout()
+	if wait == 0 {
+		return s.srv.Close()
+	}
+	end, cancel := context.WithDeadline(context.Background(), time.Now().Add(wait))
+	err := s.srv.Shutdown(end)
+	cancel()
+	if err != nil && err == context.DeadlineExceeded {
+		log.Errorf("HTTP server shutdown deadline exceeded (%s). Force closing.", wait)
+		return s.srv.Close()
+	}
+	return err
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *HttpServer) SetHeader(key, val string) {
+	s.Use(middleware.SetHeader(key, val))
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *HttpServer) serve() {
+	err := s.srv.Serve(s.lsn)
+	if skipClosedError(err) != nil {
+		log.Errorf("HTTP serving failed: %s", err)
+	}
+	cfg.Context().Stop()
+}
+
+//-----------------------------------------------------------------------------
+
+func skipClosedError(err error) error {
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}

--- a/srv/rpc/grpc.go
+++ b/srv/rpc/grpc.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package rpc
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/openmarketplaceengine/openmarketplaceengine/cfg"
+	"github.com/openmarketplaceengine/openmarketplaceengine/log"
+	"google.golang.org/grpc"
+)
+
+type GrpcServer struct {
+	lsn net.Listener
+	srv *grpc.Server
+}
+
+//-----------------------------------------------------------------------------
+
+func NewGrpcServer() *GrpcServer {
+	s := new(GrpcServer)
+	return s
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *GrpcServer) Boot() (err error) {
+	c := cfg.Grpc
+	addr := c.Addr()
+	s.lsn, err = net.Listen("tcp", addr)
+	if err != nil {
+		return
+	}
+	log.Infof("GRPC listening on %s", addr)
+	s.srv = grpc.NewServer(s.configOptions()...)
+	go s.serve()
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *GrpcServer) Stop() error {
+	if s.srv == nil {
+		return fmt.Errorf("GRPC server not initialized")
+	}
+	s.srv.GracefulStop()
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *GrpcServer) serve() {
+	err := s.srv.Serve(s.lsn)
+	if err != nil {
+		log.Errorf("GRPC serve error: %s", err)
+	}
+	cfg.Context().Stop()
+}
+
+//-----------------------------------------------------------------------------
+
+// ServerOptions returns an array of gRPC server configuration options.
+func (s *GrpcServer) configOptions() []grpc.ServerOption {
+	c := cfg.Grpc
+	opts := []grpc.ServerOption{
+		grpc.ConnectionTimeout(c.ConnectTimeout()),
+		grpc.NumStreamWorkers(c.StreamWorkers()),
+	}
+	return opts
+}

--- a/srv/srv.go
+++ b/srv/srv.go
@@ -1,0 +1,15 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package srv
+
+import (
+	"github.com/openmarketplaceengine/openmarketplaceengine/srv/htp"
+	"github.com/openmarketplaceengine/openmarketplaceengine/srv/rpc"
+)
+
+var (
+	Http = htp.NewHttpServer() //nolint
+	Grpc = rpc.NewGrpcServer()
+)


### PR DESCRIPTION
This PR brings proper server lifecycle management. If some service failed to start in the middle of a boot sequence, the already started services will be gracefully stopped in reverse order.

**Notes:**
- default exposed HTTP port now is `8080` (DigitalOcean convention)
- `go build` flags amended to reduce executable size and trim panic paths