### PR TITLE
cfg: fix environment variables whitespace trimming

### DIFF
--- a/cfg/env.go
+++ b/cfg/env.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import "os"
+
+const trimChar = ' '
+
+//-----------------------------------------------------------------------------
+
+func init() {
+	trimEnv()
+}
+
+//-----------------------------------------------------------------------------
+
+func trimEnv() {
+	env := os.Environ()
+	for _, s := range env {
+		if skipTrim(s) {
+			continue
+		}
+		k, v := envKeyVal(fastTrim(s))
+		_ = os.Setenv(k, v)
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+func envKeyVal(env string) (key, val string) {
+	for i := 0; i < len(env); i++ {
+		if env[i] == '=' {
+			key = env[:i]
+			val = env[i+1:]
+			return
+		}
+	}
+	key = env
+	return
+}
+
+//-----------------------------------------------------------------------------
+
+func skipTrim(s string) bool {
+	n := len(s)
+	return n == 0 || (s[0] > trimChar && s[n-1] > trimChar)
+}
+
+//-----------------------------------------------------------------------------
+
+func fastTrim(s string) string {
+	end := -1
+	for i := len(s); i > 0; i-- {
+		if s[i-1] <= trimChar {
+			end = i - 1
+			continue
+		}
+		break
+	}
+	if end > -1 {
+		s = s[:end]
+	}
+	for len(s) > 0 {
+		if s[0] <= trimChar {
+			s = s[1:]
+			continue
+		}
+		break
+	}
+	return s
+}

--- a/cfg/env_test.go
+++ b/cfg/env_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Drivers Cooperative. All rights reserved.
+// Use of this source code is governed by a dual
+// license that can be found in the LICENSE file.
+
+package cfg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvSkipTrim(t *testing.T) {
+	m := map[string]bool{
+		"":      true,
+		" ":     false,
+		"x=y":   true,
+		"x=y\n": false,
+		"\tx=y": false,
+	}
+	for k, v := range m {
+		require.Equal(t, v, skipTrim(k))
+	}
+}
+
+func TestEnvFastTrim(t *testing.T) {
+	m := map[string]string{
+		"":                "",
+		" ":               "",
+		"x=y":             "x=y",
+		"x=y\n":           "x=y",
+		"x=y\n\r\t\f":     "x=y",
+		"\t\n\rx=y":       "x=y",
+		"\t\n\rx=y\v\b\r": "x=y",
+	}
+	for k, v := range m {
+		require.Equal(t, v, fastTrim(k))
+	}
+}
+
+func TestEnvKeyVal(t *testing.T) {
+	ary := [][3]string{
+		{"", "", ""},
+		{"=", "", ""},
+		{"x=", "x", ""},
+		{"x=y", "x", "y"},
+		{"=y", "", "y"},
+	}
+	for i := range ary {
+		kva := &ary[i]
+		key, val := envKeyVal(kva[0])
+		require.Equal(t, kva[1], key)
+		require.Equal(t, kva[2], val)
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+func TestTrimEnv(t *testing.T) {
+	const key = "\n\t\rTRIM"
+	require.NoError(t, os.Setenv(key, "TRUE\v\n\r   "))
+	trimEnv()
+	require.NoError(t, os.Unsetenv(key))
+	env := os.Environ()
+	for i := range env {
+		if skipTrim(env[i]) {
+			continue
+		}
+		t.Fatalf("env var needs trimming: %q", env[i])
+	}
+	require.Equal(t, "TRUE", os.Getenv("TRIM"))
+}


### PR DESCRIPTION
This PR fixes environment variables whitespaces in prefix/suffix