### PR TITLE
Proof of Concept: gRPC error details

### DIFF
--- a/internal/service/worker/controller.go
+++ b/internal/service/worker/controller.go
@@ -22,7 +22,11 @@ func New() *Controller {
 func (c *Controller) GetWorker(ctx context.Context, request *workerV1beta1.GetWorkerRequest) (*workerV1beta1.GetWorkerResponse, error) {
 	v, ok := c.states[request.WorkerId]
 	if !ok {
-		return nil, status.Errorf(codes.NotFound, "WorkerId=%s", request.WorkerId)
+		st, err := status.New(codes.NotFound, "Worker not found").WithDetails(request)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, err.Error())
+		}
+		return nil, st.Err()
 	}
 	return &workerV1beta1.GetWorkerResponse{
 		Worker: &workerV1beta1.Worker{
@@ -31,6 +35,7 @@ func (c *Controller) GetWorker(ctx context.Context, request *workerV1beta1.GetWo
 		},
 	}, nil
 }
+
 func (c *Controller) SetState(ctx context.Context, request *workerV1beta1.SetStateRequest) (*workerV1beta1.SetStateResponse, error) {
 	c.states[request.WorkerId] = request.GetState()
 	return &workerV1beta1.SetStateResponse{


### PR DESCRIPTION
The [`WithDetails`](https://pkg.go.dev/google.golang.org/grpc/internal/status#Status.WithDetails) function takes a variadic list of proto messages.

The [`errdetails`](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails) package has useful messages depending on the status code.

We can include any or all of these whenever the server sends back an error. Some make sense to include on every error response, whereas others should be paired with specific error status codes.

| Message  | When to Include | Why |
| ------------- | ------------- | --- |
| [BadRequest](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#BadRequest)  | INVALID_ARGUMENT  | Contains info about invalid fields |
| [DebugInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#DebugInfo)  | On non-prod | Contains stacktrace info. For prod, send an encrypted stacktrace using [RequestInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#RequestInfo) |
| [ErrorInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#ErrorInfo) | Always? | When a 3rd-party service fails. This contains a general string-to-string map. |
| [Help](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#Help) | Sometimes | When we want to refer the client to docs |
| [LocalizedMessage](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#LocalizedMessage) | Always | Includes a locale-specific message to the end user. |
| [PreconditionFailure](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#PreconditionFailure) | FAILED_PRECONDITION | Bad system state. |
| [QuotaFailure](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#QuotaFailure) | RESOURCE_EXHAUSTED | |
| [RequestInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#RequestInfo) | Always | For returning request ID |
| [ResourceInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#ResourceInfo) | Often | For failures upon accessing a DB table, cache index, bucket, etc |
| [RetryInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#RetryInfo) | DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED, FAILED_PRECONDITION, ABORTED, DATA_LOSS | To instruct the client to wait a certain duration before retrying |

For example, for invalid requests, we'll include the [`BadRequest`](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#BadRequest) message as shown in [409d4ad](https://github.com/openmarketplaceengine/openmarketplaceengine/pull/64/commits/409d4addc6e46f5106d110ce281bb3b04cceb415).