### PR TITLE
grpc: add service registration callback handling

### DIFF
--- a/srv/rpc/grpc.go
+++ b/srv/rpc/grpc.go
@@ -17,9 +17,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+type RegFun = func(srv *grpc.Server) error
+
 type GrpcServer struct {
 	lsn net.Listener
 	srv *grpc.Server
+	reg []RegFun
 }
 
 //-----------------------------------------------------------------------------
@@ -32,14 +35,25 @@ func NewGrpcServer() *GrpcServer {
 //-----------------------------------------------------------------------------
 
 func (s *GrpcServer) Boot() (err error) {
+
 	c := cfg.Grpc
+
 	addr := c.Addr()
+
 	s.lsn, err = net.Listen("tcp", addr)
+
 	if err != nil {
 		return
 	}
+
 	log.Infof("GRPC listening on %s", addr)
+
 	s.srv = grpc.NewServer(s.configOptions()...)
+
+	if err = s.runreg(s.reg); err != nil {
+		_ = s.lsn.Close()
+		return
+	}
 
 	controller, err := location.NewController(dao.Reds.StoreClient, dao.Reds.PubSubClient)
 	if err != nil {
@@ -59,6 +73,26 @@ func (s *GrpcServer) Stop() error {
 	}
 	s.srv.GracefulStop()
 	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+// Register adds grpc.Server registration callback that is invoked
+// after server creation.
+func (s *GrpcServer) Register(fn RegFun) {
+	if fn == nil {
+		panic("Register function argument is nil")
+	}
+	s.reg = append(s.reg, fn)
+}
+
+//-----------------------------------------------------------------------------
+
+func (s *GrpcServer) runreg(reg []RegFun) (err error) {
+	for i := 0; i < len(reg) && err == nil; i++ {
+		err = reg[i](s.srv)
+	}
+	return
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds GRPC endpoint registration callback handling.

@kepkap, @kevinmichaelchen: Please use the following pattern when registering GRPC services:

```go
func init() {
  srv.Grpc.Register(callbackFunction)
}
```

The `callbackFunction(srv *grpc.Server) error` will be called after the GRPC server is created.

Returning `error` from callback will abort the server boot process.