### PR TITLE
Feat/stat core

### DIFF
--- a/dao/stat.go
+++ b/dao/stat.go
@@ -1,0 +1,18 @@
+package dao
+
+import "github.com/openmarketplaceengine/openmarketplaceengine/stat"
+
+func init() {
+	group := stat.Group("database", "PostgreSQL database stats")
+	group.Add("pool", "Connection pool stats", poolStat)
+}
+
+func poolStat(_ Context) (interface{}, error) {
+	k := stat.GetIntKeyVal()
+	s := DB().Stats()
+	k.Add("MaxOpenConn", int64(s.MaxOpenConnections))
+	k.Add("CurrOpenConn", int64(s.OpenConnections))
+	k.Add("BusyOpenConn", int64(s.InUse))
+	k.Add("IdleOpenConn", int64(s.Idle))
+	return k, nil
+}

--- a/dom/worker_stat.go
+++ b/dom/worker_stat.go
@@ -1,0 +1,31 @@
+package dom
+
+import (
+	"github.com/openmarketplaceengine/openmarketplaceengine/dao"
+	"github.com/openmarketplaceengine/openmarketplaceengine/stat"
+)
+
+func init() {
+	wg := stat.Group("workers", "Workers stats")
+	wg.Add("status", "Workers status info", workerStatus)
+}
+
+func workerStatus(ctx Context) (interface{}, error) {
+	k := stat.GetIntKeyVal()
+	sql := dao.NewSQL(
+		`select status, count(status)
+			from worker
+			group by status
+			order by 1`)
+	err := sql.QueryEach(ctx, func(rows *dao.Rows) {
+		var status, count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			return
+		}
+		k.Add(WorkerStatus(status).String(), count)
+	})
+	if k.Len() > 0 {
+		k.Add("total", k.Total())
+	}
+	return k, err
+}

--- a/main.go
+++ b/main.go
@@ -24,8 +24,8 @@ func init() {
 	boot.Use("PGDB", dao.Pgdb)
 	boot.Use("REDS", dao.Reds)
 	boot.Add("STAT", stat.Boot, nil)
-	boot.Use("HTTP", srv.Http)
 	boot.Use("GRPC", srv.Grpc)
+	boot.Use("HTTP", srv.Http)
 
 	location.GrpcRegister()
 	tollgate.GrpcRegister()

--- a/main.go
+++ b/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/openmarketplaceengine/openmarketplaceengine/internal/service/location"
 	"github.com/openmarketplaceengine/openmarketplaceengine/internal/service/tollgate"
@@ -19,15 +17,12 @@ import (
 	"github.com/openmarketplaceengine/openmarketplaceengine/stat"
 )
 
-var started = time.Now()
-
 var boot cfg.BootList
 
 func init() {
 	boot.Add("DATA", dom.Boot, nil)
 	boot.Use("PGDB", dao.Pgdb)
 	boot.Use("REDS", dao.Reds)
-	boot.Add("URLS", route, nil)
 	boot.Add("STAT", stat.Boot, nil)
 	boot.Use("HTTP", srv.Http)
 	boot.Use("GRPC", srv.Grpc)
@@ -82,28 +77,6 @@ func main() {
 	}
 
 	log.Infof("Done")
-}
-
-//-----------------------------------------------------------------------------
-
-func route() error {
-	if name := cfg.Http.Name; len(name) > 0 {
-		srv.Http.SetHeader("Server", name)
-	}
-	srv.Http.Get("/uptime", uptime)
-	return nil
-}
-
-//-----------------------------------------------------------------------------
-
-func uptime(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		code := http.StatusMethodNotAllowed
-		http.Error(w, http.StatusText(code), code)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, _ = fmt.Fprintf(w, "{\"uptime\": %d}", time.Since(started)/time.Second)
 }
 
 //-----------------------------------------------------------------------------

--- a/stat/boot.go
+++ b/stat/boot.go
@@ -1,0 +1,18 @@
+package stat
+
+import "github.com/openmarketplaceengine/openmarketplaceengine/cfg"
+
+const pfxErr = "stat"
+
+var state cfg.State64
+
+//-----------------------------------------------------------------------------
+
+func Boot() error {
+	if !state.TryBoot() {
+		return state.StateError(pfxErr)
+	}
+	bootProm()
+	state.SetRunning()
+	return nil
+}

--- a/stat/boot.go
+++ b/stat/boot.go
@@ -20,7 +20,7 @@ func Boot() error {
 	slog = log.Named("STAT")
 	_ = slog
 	bootProm()
-	bootHttp()
+	bootHTTP()
 	state.SetRunning()
 	return nil
 }

--- a/stat/boot.go
+++ b/stat/boot.go
@@ -1,10 +1,15 @@
 package stat
 
-import "github.com/openmarketplaceengine/openmarketplaceengine/cfg"
+import (
+	"github.com/openmarketplaceengine/openmarketplaceengine/cfg"
+	"github.com/openmarketplaceengine/openmarketplaceengine/log"
+)
 
 const pfxErr = "stat"
 
 var state cfg.State64
+
+var slog = log.Log()
 
 //-----------------------------------------------------------------------------
 
@@ -12,6 +17,8 @@ func Boot() error {
 	if !state.TryBoot() {
 		return state.StateError(pfxErr)
 	}
+	slog = log.Named("STAT")
+	slog.Debugf("init prometheus")
 	bootProm()
 	state.SetRunning()
 	return nil

--- a/stat/boot.go
+++ b/stat/boot.go
@@ -18,8 +18,9 @@ func Boot() error {
 		return state.StateError(pfxErr)
 	}
 	slog = log.Named("STAT")
-	slog.Debugf("init prometheus")
+	_ = slog
 	bootProm()
+	bootHttp()
 	state.SetRunning()
 	return nil
 }

--- a/stat/http.go
+++ b/stat/http.go
@@ -8,7 +8,7 @@ import (
 
 var _http List
 
-func bootHttp() {
+func bootHTTP() {
 	const path = "/status"
 	slog.Infof("HTTP stats endpoint: %s", path)
 	srv.Http.Get(path, httpStat)

--- a/stat/http.go
+++ b/stat/http.go
@@ -1,0 +1,31 @@
+package stat
+
+import (
+	"net/http"
+
+	"github.com/openmarketplaceengine/openmarketplaceengine/srv"
+)
+
+var _http List
+
+func bootHttp() {
+	const path = "/status"
+	slog.Infof("HTTP stats endpoint: %s", path)
+	srv.Http.Get(path, httpStat)
+}
+
+func httpStat(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	buf := AcquireJSONBuffer(2)
+	defer buf.Release()
+	listJSON(r.Context(), &_http, buf)
+	_, _ = buf.WriteTo(w)
+}
+
+func AddStat(name string, help string, stat Func) {
+	_http.Add(name, help, stat)
+}
+
+func Group(name string, help string) *List {
+	return _http.Group(name, help)
+}

--- a/stat/jbuf.go
+++ b/stat/jbuf.go
@@ -1,0 +1,845 @@
+package stat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+	"unicode/utf8"
+	"unsafe"
+)
+
+const (
+	MaxIndent = 128
+	defBufLen = 1024
+)
+
+type jbtoken int
+
+const (
+	jbStart jbtoken = iota
+	jbObject
+	jbObjEnd
+	jbObjKey
+	jbArray
+	jbAryEnd
+	jbValue
+	jbComma
+)
+
+type JSONBuffer struct {
+	buf []byte  // buffer
+	tok jbtoken // current token
+	pos int     // current token pos
+	lev int     // nested object/array level
+	ind int     // indent level
+	inl int     // inline level
+}
+
+type JSONAppender interface {
+	AppendJSON(b []byte) ([]byte, error)
+}
+
+type JSONWriter interface {
+	WriteJSON(b *JSONBuffer) error
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Len() int {
+	return len(b.buf)
+}
+
+func (b *JSONBuffer) Cap() int {
+	return cap(b.buf)
+}
+
+func (b *JSONBuffer) Buf() []byte {
+	return b.buf
+}
+
+func (b *JSONBuffer) Cut(pos int) {
+	b.buf = b.buf[:pos]
+}
+
+func (b *JSONBuffer) End() []byte {
+	if b.ind > 0 {
+		b.NewLine()
+	}
+	return b.buf
+}
+
+func (b *JSONBuffer) UnsafeString() string {
+	return *(*string)(unsafe.Pointer(&b.buf))
+}
+
+//-----------------------------------------------------------------------------
+// Pool Management
+//-----------------------------------------------------------------------------
+
+var _jsonBufferPool = sync.Pool{New: func() interface{} {
+	return &JSONBuffer{
+		buf: make([]byte, 0, defBufLen),
+	}
+}}
+
+func AcquireJSONBuffer(indent int) *JSONBuffer {
+	buf := _jsonBufferPool.Get().(*JSONBuffer)
+	return buf.WithIndent(indent)
+}
+
+func (b *JSONBuffer) Reset() {
+	if len(b.buf) > 0 {
+		b.buf = b.buf[:0]
+	}
+	b.tok = jbStart
+	b.pos = 0
+	b.lev = 0
+	b.ind = 0
+	b.inl = 0
+}
+
+func (b *JSONBuffer) Release() {
+	b.Reset()
+	_jsonBufferPool.Put(b)
+}
+
+//-----------------------------------------------------------------------------
+// Indent
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) WithIndent(indent int) *JSONBuffer {
+	switch {
+	case indent <= 0:
+		b.ind = 0
+	case indent > MaxIndent:
+		b.ind = MaxIndent
+	default:
+		b.ind = indent
+	}
+	return b
+}
+
+// Indent returns current indent level.
+func (b *JSONBuffer) Indent() int {
+	if b.inl == 0 {
+		return b.ind * b.lev
+	}
+	return 0
+}
+
+// ConfigIndent returns JSONBuffer indent value.
+func (b *JSONBuffer) ConfigIndent() int {
+	return b.ind
+}
+
+func (b *JSONBuffer) ShouldIndent() bool {
+	return b.ind > 0 && b.inl == 0
+}
+
+func (b *JSONBuffer) IgnoreIndent() bool {
+	return b.ind == 0 || b.inl > 0
+}
+
+//-----------------------------------------------------------------------------
+// Inline
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Inline(inline bool) {
+	if inline {
+		b.inl++
+	} else if b.inl > 0 {
+		b.inl--
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Token
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) setval() {
+	b.tok = jbValue
+	b.pos = len(b.buf)
+}
+
+func (b *JSONBuffer) setpos(tok jbtoken) {
+	b.tok = tok
+	b.pos = len(b.buf)
+}
+
+func (b *JSONBuffer) srctok() jbtoken {
+	for i := len(b.buf); i > 0; i-- {
+		b.pos = i
+		switch b.buf[i-1] {
+		case ' ', '\n', '\r', '\t':
+			// ignore
+		case '}':
+			return jbObjEnd
+		case ']':
+			return jbAryEnd
+		case ',':
+			return jbComma
+		case '{':
+			return jbObject
+		case '[':
+			return jbArray
+		case ':':
+			return jbObjKey
+		default:
+			return jbValue
+		}
+	}
+	b.pos = 0
+	return jbStart
+}
+
+//-----------------------------------------------------------------------------
+// Basic Types
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Null() {
+	b.buf = append(b.buf, 'n', 'u', 'l', 'l')
+	b.setval()
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) True() {
+	b.buf = append(b.buf, 't', 'r', 'u', 'e')
+	b.setval()
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) False() {
+	b.buf = append(b.buf, 'f', 'a', 'l', 's', 'e')
+	b.setval()
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Bool(v bool) {
+	if v {
+		b.True()
+		return
+	}
+	b.False()
+}
+
+//-----------------------------------------------------------------------------
+// JSON String
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) String(s string, safeHTML bool) {
+	b.buf = append(b.buf, '"')
+	b.buf = escape(b.buf, s, safeHTML)
+	b.buf = append(b.buf, '"')
+	b.setval()
+}
+
+func (b *JSONBuffer) Stringf(format string, args ...interface{}) {
+	b.String(fmt.Sprintf(format, args...), true)
+}
+
+func (b *JSONBuffer) BinaryString(s []byte, safeHTML bool) {
+	if s == nil {
+		b.Null()
+		return
+	}
+	b.buf = append(b.buf, '"')
+	v := *(*string)(unsafe.Pointer(&b))
+	b.buf = escape(b.buf, v, safeHTML)
+	b.buf = append(b.buf, '"')
+	b.setval()
+}
+
+func (b *JSONBuffer) RawString(s string) {
+	b.buf = append(b.buf, '"')
+	b.buf = append(b.buf, s...)
+	b.buf = append(b.buf, '"')
+	b.setval()
+}
+
+//-----------------------------------------------------------------------------
+// Append
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) AppendFrom(a JSONAppender) error {
+	return b.AppendFunc(a.AppendJSON)
+}
+
+func (b *JSONBuffer) AppendFunc(f func(b []byte) ([]byte, error)) error {
+	buf, err := f(b.buf)
+	if err == nil && len(buf) > len(b.buf) {
+		b.buf = buf
+		b.srctok()
+	}
+	return err
+}
+
+func (b *JSONBuffer) AppendJSON(src []byte) error {
+	if src == nil {
+		b.Null()
+		return nil
+	}
+	var pfx, ind string
+	if b.ShouldIndent() {
+		pfx = whiteSpace(b.Indent())
+		ind = whiteSpace(b.ConfigIndent())
+	}
+	dst := AcquireByteBuffer(len(src) + ((len(pfx) + len(ind)) * 32))
+	defer ReleaseByteBuffer(dst)
+	err := json.Indent(dst, src, pfx, ind)
+	if err == nil {
+		b.buf = append(b.buf, dst.Bytes()...)
+		b.srctok()
+	}
+	return err
+}
+
+//-----------------------------------------------------------------------------
+// Encode
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) EncodeJSON(v interface{}) error {
+	if v == nil {
+		b.Null()
+		return nil
+	}
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return b.AppendJSON(buf)
+}
+
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) WriteFrom(w JSONWriter) error {
+	err := w.WriteJSON(b)
+	if err == nil {
+		b.srctok()
+	}
+	return err
+}
+
+//-----------------------------------------------------------------------------
+// interface{}
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Value(i interface{}) error {
+	if i == nil {
+		b.Null()
+		return nil
+	}
+	switch v := i.(type) {
+	case JSONWriter:
+		return b.WriteFrom(v)
+	case JSONAppender:
+		return b.AppendFrom(v)
+	case string:
+		b.String(v, true)
+	case int64:
+		b.Int64(v)
+	case int:
+		b.Int(v)
+	case uint64:
+		b.Uint64(v)
+	case uint:
+		b.Uint(v)
+	case time.Time:
+		b.Time(v)
+	case time.Duration:
+		b.Seconds(v)
+	case json.RawMessage:
+		return b.AppendJSON(v)
+	case bool:
+		b.Bool(v)
+	default:
+		return b.EncodeJSON(i)
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+// start / close
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) start(c byte, start jbtoken) {
+	b.lev++
+	b.tok = start
+	if b.IgnoreIndent() {
+		b.buf = append(b.buf, c)
+		b.pos = len(b.buf)
+		return
+	}
+	b.buf = append(b.buf, c, '\n')
+	b.pos = len(b.buf) - 1
+	b.indent()
+}
+
+func (b *JSONBuffer) close(c byte, start, close jbtoken) {
+	ind := b.ShouldIndent()
+	switch b.tok {
+	case start:
+		if ind {
+			b.Cut(b.pos)
+		}
+	case jbComma:
+		b.Cut(b.pos - 1)
+	}
+	b.lev--
+	if ind {
+		b.eolind()
+	}
+	b.buf = append(b.buf, c)
+	b.pos = len(b.buf)
+	b.tok = close
+}
+
+//-----------------------------------------------------------------------------
+// Object
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) ObjectStart() {
+	b.start('{', jbObject)
+}
+
+func (b *JSONBuffer) ObjectClose() {
+	b.close('}', jbObject, jbObjEnd)
+}
+
+func (b *JSONBuffer) EmptyObject() {
+	b.buf = append(b.buf, '{', '}')
+	b.setpos(jbObjEnd)
+}
+
+//-----------------------------------------------------------------------------
+// Object Key
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) KeyEsc(key string) {
+	b.Key(key, true)
+}
+
+func (b *JSONBuffer) KeyRaw(key string) {
+	b.Key(key, false)
+}
+
+func (b *JSONBuffer) Key(key string, esc bool) {
+	b.tok = jbObjKey
+	b.buf = append(b.buf, '"')
+	if esc {
+		b.buf = escape(b.buf, key, true)
+	} else {
+		b.buf = append(b.buf, key...)
+	}
+	if b.ind > 0 {
+		b.buf = append(b.buf, '"', ':', ' ')
+		b.pos = len(b.buf) - 1
+	} else {
+		b.buf = append(b.buf, '"', ':')
+		b.pos = len(b.buf)
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Array
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) ArrayStart() {
+	b.start('[', jbArray)
+}
+
+func (b *JSONBuffer) ArrayClose() {
+	b.close(']', jbArray, jbAryEnd)
+}
+
+func (b *JSONBuffer) EmptyArray() {
+	b.buf = append(b.buf, '[', ']')
+	b.setpos(jbAryEnd)
+}
+
+//-----------------------------------------------------------------------------
+// Comma
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Comma() {
+	if b.tok == jbComma {
+		return
+	}
+	b.tok = jbComma
+	switch {
+	case b.ind == 0:
+		b.buf = append(b.buf, ',')
+		b.pos = len(b.buf)
+	case b.inl > 0:
+		b.buf = append(b.buf, ',', ' ')
+		b.pos = len(b.buf) - 1
+	default:
+		b.buf = append(b.buf, ',', '\n')
+		b.pos = len(b.buf) - 1
+		b.indent()
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Char / Rune
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Char(c byte) {
+	b.buf = append(b.buf, c)
+}
+
+func (b *JSONBuffer) Char2(c1, c2 byte) {
+	b.buf = append(b.buf, c1, c2)
+}
+
+func (b *JSONBuffer) Chars(chars ...byte) {
+	b.buf = append(b.buf, chars...)
+}
+
+func (b *JSONBuffer) Rune(r rune) {
+	if r < utf8.RuneSelf {
+		b.buf = append(b.buf, byte(r))
+		return
+	}
+	b.runeMust(r)
+}
+
+func (b *JSONBuffer) runeMust(r rune) {
+	n := len(b.buf)
+	b.buf = append(b.buf, ' ', ' ', ' ', ' ')
+	n += utf8.EncodeRune(b.buf[n:], r)
+	b.buf = b.buf[:n]
+}
+
+//-----------------------------------------------------------------------------
+// Formatting
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) NewLine() {
+	if n := len(b.buf); n > 0 && b.buf[n-1] != '\n' {
+		b.buf = append(b.buf, '\n')
+	}
+}
+
+func (b *JSONBuffer) Space(n int) {
+	const space = "                                                            "
+	const splen = len(space)
+	if n <= splen {
+		b.buf = append(b.buf, space[:n]...)
+		return
+	}
+	for n >= splen {
+		b.buf = append(b.buf, space...)
+		n -= splen
+	}
+	if n > 0 {
+		b.buf = append(b.buf, space[:n]...)
+	}
+}
+
+func (b *JSONBuffer) indent() {
+	b.Space(b.ind * b.lev)
+}
+
+func (b *JSONBuffer) eolind() {
+	b.buf = append(b.buf, '\n')
+	b.Space(b.ind * b.lev)
+}
+
+//-----------------------------------------------------------------------------
+// Int
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Int64(i int64) {
+	b.buf = strconv.AppendInt(b.buf, i, 10)
+	b.setval()
+}
+
+func (b *JSONBuffer) Int32(i int32) {
+	b.Int64(int64(i))
+}
+
+func (b *JSONBuffer) Int16(i int16) {
+	b.Int64(int64(i))
+}
+
+func (b *JSONBuffer) Int8(i int8) {
+	b.Int64(int64(i))
+}
+
+func (b *JSONBuffer) Int(i int) {
+	b.Int64(int64(i))
+}
+
+//-----------------------------------------------------------------------------
+// Uint
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Uint64(i uint64) {
+	b.buf = strconv.AppendUint(b.buf, i, 10)
+	b.setval()
+}
+
+func (b *JSONBuffer) Uint32(i uint32) {
+	b.Uint64(uint64(i))
+}
+
+func (b *JSONBuffer) Uint16(i uint16) {
+	b.Uint64(uint64(i))
+}
+
+func (b *JSONBuffer) Uint8(i uint8) {
+	b.Uint64(uint64(i))
+}
+
+func (b *JSONBuffer) Uint(i uint) {
+	b.Uint64(uint64(i))
+}
+
+func (b *JSONBuffer) Uintptr(i uintptr) {
+	b.Uint64(uint64(i))
+}
+
+//-----------------------------------------------------------------------------
+// Time
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) Time(t time.Time) {
+	b.RFC3339Time(t)
+}
+
+func (b *JSONBuffer) UnixTime(t time.Time) {
+	b.Int64(t.Unix())
+}
+
+func (b *JSONBuffer) RFC3339Time(t time.Time) {
+	b.buf = append(b.buf, '"')
+	b.buf = t.AppendFormat(b.buf, time.RFC3339Nano)
+	b.buf = append(b.buf, '"')
+	b.setval()
+}
+
+func (b *JSONBuffer) Seconds(d time.Duration) {
+	d /= time.Second
+	b.Int64(int64(d))
+}
+
+//-----------------------------------------------------------------------------
+// Output
+//-----------------------------------------------------------------------------
+
+func (b *JSONBuffer) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(b.End())
+	return int64(n), err
+}
+
+func (b *JSONBuffer) Print() {
+	b.NewLine()
+	_, err := b.WriteTo(os.Stdout)
+	if err != nil {
+		println("JSONBuffer write to stdout failed:", err.Error())
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+type JSONUnixTime struct {
+	time.Time
+}
+
+func (t JSONUnixTime) WriteJSON(b *JSONBuffer) error {
+	b.Int64(t.Unix())
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+func whiteSpace(n int) string {
+	const space = "                                                            "
+	const splen = len(space)
+	if n <= splen {
+		return space[:n]
+	}
+	buf := make([]byte, 0, n)
+	for n >= splen {
+		buf = append(buf, space...)
+		n -= splen
+	}
+	if n > 0 {
+		buf = append(buf, space[:n]...)
+	}
+	return *(*string)(unsafe.Pointer(&buf))
+}
+
+//-----------------------------------------------------------------------------
+// String Escape
+//-----------------------------------------------------------------------------
+
+func escape(b []byte, s string, safeHTML bool) []byte {
+	const hex = "0123456789abcdef"
+	var esc = escASCII
+	if safeHTML {
+		esc = escHTML
+	}
+	start := 0
+	for i := 0; i < len(s); {
+		if c := s[i]; c < utf8.RuneSelf {
+			e := esc[c]
+			if e == 0 {
+				i++
+				continue
+			}
+			if start < i {
+				b = append(b, s[start:i]...)
+			}
+			if e == 1 {
+				b = append(b, '\\', 'u', '0', '0', hex[c>>4], hex[c&0xF])
+			} else {
+				b = append(b, '\\', e)
+			}
+			i++
+			start = i
+			continue
+		}
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				b = append(b, s[start:i]...)
+			}
+			b = append(b, '\\', 'u', 'f', 'f', 'f', 'd')
+			i += size
+			start = i
+			continue
+		}
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				b = append(b, s[start:i]...)
+			}
+			b = append(b, '\\', 'u', '2', '0', '2', hex[c&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	if start < len(s) {
+		b = append(b, s[start:]...)
+	}
+	return b
+}
+
+//-----------------------------------------------------------------------------
+// bytes.Buffer Pool
+//-----------------------------------------------------------------------------
+
+var _byteBufferPool = sync.Pool{New: func() interface{} {
+	return new(bytes.Buffer)
+}}
+
+func AcquireByteBuffer(size int) *bytes.Buffer {
+	buf := _byteBufferPool.Get().(*bytes.Buffer)
+	if size > 0 && size > buf.Cap() {
+		buf.Grow(size)
+	}
+	return buf
+}
+
+func ReleaseByteBuffer(buf *bytes.Buffer) {
+	buf.Reset()
+	_byteBufferPool.Put(buf)
+}
+
+//-----------------------------------------------------------------------------
+// JSON Field Helpers
+//-----------------------------------------------------------------------------
+
+func CheckJSONField(field string, errorPrefix string) error {
+	if len(errorPrefix) == 0 {
+		errorPrefix = "JSON field"
+	}
+	n := len(field)
+	if n == 0 {
+		return fmt.Errorf("%s is empty", errorPrefix)
+	}
+	for i := 0; i < n; i++ {
+		if c := field[i]; ascii[c] == 0 {
+			r, _ := utf8.DecodeRuneInString(field[i:])
+			return fmt.Errorf("%s has invalid character %q at index %d", errorPrefix, r, i+1)
+		}
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func MustJSONField(s string, errorPrefix string) {
+	if err := CheckJSONField(s, errorPrefix); err != nil {
+		panic(err)
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Tables
+//-----------------------------------------------------------------------------
+
+var ascii = [256]uint8{
+	'0': 1, '1': 1, '2': 1, '3': 1, '4': 1, '5': 1, '6': 1, '7': 1, '8': 1, '9': 1,
+	'A': 1, 'B': 1, 'C': 1, 'D': 1, 'E': 1, 'F': 1, 'G': 1, 'H': 1, 'I': 1, 'J': 1,
+	'K': 1, 'L': 1, 'M': 1, 'N': 1, 'O': 1, 'P': 1, 'Q': 1, 'R': 1, 'S': 1, 'T': 1,
+	'U': 1, 'V': 1, 'W': 1, 'X': 1, 'Y': 1, 'Z': 1,
+	'a': 1, 'b': 1, 'c': 1, 'd': 1, 'e': 1, 'f': 1, 'g': 1, 'h': 1, 'i': 1, 'j': 1,
+	'k': 1, 'l': 1, 'm': 1, 'n': 1, 'o': 1, 'p': 1, 'q': 1, 'r': 1, 's': 1, 't': 1,
+	'u': 1, 'v': 1, 'w': 1, 'x': 1, 'y': 1, 'z': 1,
+	'-': 1, '_': 1, '@': 1, '*': 1,
+}
+
+var escASCII = [128]uint8{
+	0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1,
+	7:  1,   // \a
+	8:  1,   // \b
+	9:  't', // \t
+	10: 'n', // \n
+	11: 1,   // \v
+	12: 1,   // \f
+	13: 'r', // \r
+	14: 1, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1,
+	20: 1, 21: 1, 22: 1, 23: 1, 24: 1, 25: 1,
+	26: 1, 27: 1, 28: 1, 29: 1, 30: 1, 31: 1,
+	'"':  '"',
+	'\\': '\\',
+}
+
+var escHTML = [128]uint8{
+	0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1,
+	7:  1,   // \a
+	8:  1,   // \b
+	9:  't', // \t
+	10: 'n', // \n
+	11: 1,   // \v
+	12: 1,   // \f
+	13: 'r', // \r
+	14: 1, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1,
+	20: 1, 21: 1, 22: 1, 23: 1, 24: 1, 25: 1,
+	26: 1, 27: 1, 28: 1, 29: 1, 30: 1, 31: 1,
+	'"':  '"',
+	'\\': '\\',
+	'<':  1,
+	'>':  1,
+	'&':  1,
+}

--- a/stat/jbuf.go
+++ b/stat/jbuf.go
@@ -88,7 +88,7 @@ var _jsonBufferPool = sync.Pool{New: func() interface{} {
 }}
 
 func AcquireJSONBuffer(indent int) *JSONBuffer {
-	buf := _jsonBufferPool.Get().(*JSONBuffer)
+	buf, _ := _jsonBufferPool.Get().(*JSONBuffer)
 	return buf.WithIndent(indent)
 }
 
@@ -171,7 +171,7 @@ func (b *JSONBuffer) setpos(tok jbtoken) {
 	b.pos = len(b.buf)
 }
 
-func (b *JSONBuffer) srctok() jbtoken {
+func (b *JSONBuffer) srctok() jbtoken { //nolint
 	for i := len(b.buf); i > 0; i-- {
 		b.pos = i
 		switch b.buf[i-1] {
@@ -382,7 +382,7 @@ func (b *JSONBuffer) start(c byte, start jbtoken) {
 	b.indent()
 }
 
-func (b *JSONBuffer) close(c byte, start, close jbtoken) {
+func (b *JSONBuffer) close(c byte, start, endtok jbtoken) {
 	ind := b.ShouldIndent()
 	switch b.tok {
 	case start:
@@ -398,7 +398,7 @@ func (b *JSONBuffer) close(c byte, start, close jbtoken) {
 	}
 	b.buf = append(b.buf, c)
 	b.pos = len(b.buf)
-	b.tok = close
+	b.tok = endtok
 }
 
 //-----------------------------------------------------------------------------
@@ -753,7 +753,7 @@ var _byteBufferPool = sync.Pool{New: func() interface{} {
 }}
 
 func AcquireByteBuffer(size int) *bytes.Buffer {
-	buf := _byteBufferPool.Get().(*bytes.Buffer)
+	buf, _ := _byteBufferPool.Get().(*bytes.Buffer)
 	if size > 0 && size > buf.Cap() {
 		buf.Grow(size)
 	}

--- a/stat/jbuf_test.go
+++ b/stat/jbuf_test.go
@@ -1,0 +1,82 @@
+package stat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+//-----------------------------------------------------------------------------
+
+func TestJSONBuffer_Rune(t *testing.T) {
+	s := "abcdœΩåßç√©∆˚🙂🐸🥝🇦🇶✅"
+	var b JSONBuffer
+	for _, r := range s {
+		b.Rune(r)
+	}
+	require.Equal(t, s, b.UnsafeString())
+}
+
+//-----------------------------------------------------------------------------
+
+func TestJSONBuffer_StrEsc(t *testing.T) {
+	smap := map[string]string{
+		"":       `""`,
+		`""`:     `"\"\""`,
+		"abcd":   `"abcd"`,
+		"\n\t\r": `"\n\t\r"`,
+		`<&>`:    `"\u003c\u0026\u003e"`,
+		`"<&>"`:  `"\"\u003c\u0026\u003e\""`,
+		"\\":     `"\\"`,
+		"abcdœΩåßç√©∆˚🙂🐸🥝🇦🇶✅": `"abcdœΩåßç√©∆˚🙂🐸🥝🇦🇶✅"`,
+	}
+	var b JSONBuffer
+	for k, v := range smap {
+		b.Reset()
+		b.String(k, true)
+		require.Equal(t, v, b.UnsafeString())
+	}
+}
+
+//-----------------------------------------------------------------------------
+
+func TestJSONBuffer_EmptyArrayIndent(t *testing.T) {
+	b := AcquireJSONBuffer(2)
+	t.Cleanup(b.Release)
+	b.ArrayStart()
+	b.ArrayStart()
+	b.ArrayStart()
+	b.ArrayClose()
+	b.ArrayClose()
+	b.ArrayClose()
+	want := "[\n  [\n    [\n    ]\n  ]\n]\n"
+	require.Equal(t, want, string(b.End()))
+}
+
+func TestJSONBuffer_ArrayInline(t *testing.T) {
+	var b JSONBuffer
+	fillArray(&b, 2, true)
+	b.Print()
+}
+
+func fillArray(b *JSONBuffer, indent int, inline bool) {
+	now := time.Now()
+	b.Reset()
+	b.WithIndent(indent)
+	b.Inline(inline)
+	b.ArrayStart()
+	b.Null()
+	b.Comma()
+	b.Int(1)
+	b.Comma()
+	b.True()
+	b.Comma()
+	b.False()
+	b.Comma()
+	_ = b.Value(now)
+	b.Comma()
+	b.UnixTime(now)
+	b.Comma()
+	b.ArrayClose()
+}

--- a/stat/keyval.go
+++ b/stat/keyval.go
@@ -1,0 +1,118 @@
+package stat
+
+import (
+	"database/sql"
+	"sync"
+)
+
+//-----------------------------------------------------------------------------
+// IntKeyVal
+//-----------------------------------------------------------------------------
+
+type IntKeyVal struct {
+	Key []string
+	Val []int64
+}
+
+//-----------------------------------------------------------------------------
+
+var _intKeyValPool = sync.Pool{New: func() interface{} {
+	return new(IntKeyVal).Alloc(16)
+}}
+
+func GetIntKeyVal() *IntKeyVal {
+	return _intKeyValPool.Get().(*IntKeyVal)
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Get(index int) (string, int64) {
+	return kv.Key[index], kv.Val[index]
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Add(key string, val int64) {
+	kv.Key = append(kv.Key, key)
+	kv.Val = append(kv.Val, val)
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Alloc(size int) *IntKeyVal {
+	kv.Key = make([]string, 0, size)
+	kv.Val = make([]int64, 0, size)
+	return kv
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Len() int {
+	return len(kv.Key)
+}
+
+func (kv *IntKeyVal) Empty() bool {
+	return len(kv.Key) == 0
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Scan(rows *sql.Rows) error {
+	var key string
+	var val int64
+	for rows.Next() {
+		err := rows.Scan(&key, &val)
+		if err != nil {
+			return err
+		}
+		kv.Add(key, val)
+	}
+	return nil
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Total() int64 {
+	var tot int64
+	for i := 0; i < len(kv.Val); i++ {
+		tot += kv.Val[i]
+	}
+	return tot
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Release() {
+	kv.Reset()
+	_intKeyValPool.Put(kv)
+}
+
+//-----------------------------------------------------------------------------
+
+func (kv *IntKeyVal) Reset() {
+	if n := len(kv.Key); n > 0 {
+		for i := 0; i < n; i++ {
+			kv.Key[i] = ""
+		}
+		kv.Key = kv.Key[:0]
+		kv.Val = kv.Val[:0]
+	}
+}
+
+func (kv *IntKeyVal) WriteJSON(b *JSONBuffer) error {
+	if kv.Empty() {
+		b.EmptyObject()
+		return nil
+	}
+	b.ObjectStart()
+	for i := 0; i < kv.Len(); i++ {
+		if i > 0 {
+			b.Comma()
+		}
+		key, val := kv.Get(i)
+		b.Key(key, true)
+		b.Int64(val)
+	}
+	b.ObjectClose()
+	return nil
+}

--- a/stat/prom.go
+++ b/stat/prom.go
@@ -1,22 +1,12 @@
 package stat
 
 import (
-	"github.com/openmarketplaceengine/openmarketplaceengine/cfg"
 	"github.com/openmarketplaceengine/openmarketplaceengine/srv"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const pfxErr = "stat"
-
-var state cfg.State64
-
 //-----------------------------------------------------------------------------
 
-func Boot() error {
-	if !state.TryBoot() {
-		return state.StateError(pfxErr)
-	}
+func bootProm() {
 	srv.Http.Handle("/metrics", promhttp.Handler())
-	state.SetRunning()
-	return nil
 }

--- a/stat/prom.go
+++ b/stat/prom.go
@@ -8,5 +8,7 @@ import (
 //-----------------------------------------------------------------------------
 
 func bootProm() {
-	srv.Http.Handle("/metrics", promhttp.Handler())
+	const path = "/metrics"
+	slog.Infof("Prometheus endpoint: %s", path)
+	srv.Http.Handle(path, promhttp.Handler())
 }

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -1,0 +1,170 @@
+package stat
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+type (
+	Context = context.Context
+)
+
+type Func = func(ctx Context) (interface{}, error)
+
+type Stat struct {
+	name string
+	help string
+	stat Func
+	list *List // sub stats
+}
+
+type List struct {
+	stat []*Stat
+}
+
+type Releaser interface {
+	Release()
+}
+
+//-----------------------------------------------------------------------------
+// Stat
+//-----------------------------------------------------------------------------
+
+func (s *Stat) Skip() bool {
+	return s.stat == nil && (s.list == nil || s.list.Len() == 0)
+}
+
+func (s *Stat) Group() bool {
+	return s.list != nil
+}
+
+func (s *Stat) GroupCount() int {
+	if s.list != nil {
+		return s.list.Len()
+	}
+	return 0
+}
+
+//-----------------------------------------------------------------------------
+// List
+//-----------------------------------------------------------------------------
+
+func (ls *List) Add(name string, help string, stat Func) {
+	ls.checkName(name, "Stat name")
+	if stat == nil {
+		panic("Stat func is nil")
+	}
+	ls.add(&Stat{name: name, help: help, stat: stat})
+}
+
+func (ls *List) Group(name string, help string) *List {
+	MustJSONField(name, "Group name")
+	if stat := ls.Stat(name); stat != nil {
+		if stat.list == nil {
+			panic(fmt.Sprintf("Group name is in use by a Stat: %q", name))
+		}
+		return stat.list
+	}
+	group := &Stat{name: name, list: new(List)}
+	if len(help) > 0 {
+		group.help = help
+	}
+	ls.add(group)
+	return group.list
+}
+
+//-----------------------------------------------------------------------------
+
+func (ls *List) Len() int {
+	return len(ls.stat)
+}
+
+func (ls *List) Less(i, j int) bool {
+	return ls.stat[i].name < ls.stat[j].name
+}
+
+func (ls *List) Swap(i, j int) {
+	ls.stat[i], ls.stat[j] = ls.stat[j], ls.stat[i]
+}
+
+func (ls *List) sort() {
+	sort.Sort(ls)
+}
+
+//-----------------------------------------------------------------------------
+
+func (ls *List) Find(name string) int {
+	a := ls.stat
+	n := len(a)
+	x := sort.Search(n, func(i int) bool {
+		return a[i].name >= name
+	})
+	if x < n && a[x].name == name {
+		return x
+	}
+	return -1
+}
+
+func (ls *List) Stat(name string) *Stat {
+	if x := ls.Find(name); x != -1 {
+		return ls.stat[x]
+	}
+	return nil
+}
+
+func (ls *List) checkName(name string, errorPrefix string) {
+	MustJSONField(name, errorPrefix)
+	if x := ls.Find(name); x != -1 {
+		panic(fmt.Errorf("%s is already in use: %q", errorPrefix, name))
+	}
+}
+
+func (ls *List) add(stat *Stat) {
+	ls.stat = append(ls.stat, stat)
+	ls.sort()
+}
+
+//-----------------------------------------------------------------------------
+
+func listJSON(ctx Context, list *List, buf *JSONBuffer) {
+	n := list.Len()
+	if n == 0 {
+		buf.EmptyObject()
+		return
+	}
+	buf.ObjectStart()
+	for i := 0; i < n; i++ {
+		s := list.stat[i]
+		if s.Skip() {
+			continue
+		}
+		buf.Key(s.name, false)
+		if s.Group() {
+			listJSON(ctx, s.list, buf)
+			buf.Comma()
+			continue
+		}
+		val, err := s.stat(ctx)
+		if err != nil {
+			slog.Errorf("%q stat failed: %s", s.name, err)
+			buf.Stringf("ERR: %s", err)
+		} else {
+			err = buf.Value(val)
+			if err != nil {
+				slog.Errorf("%q JSON failed: %s", err)
+			}
+		}
+		release(val)
+		buf.Comma()
+	}
+	buf.ObjectClose()
+}
+
+//-----------------------------------------------------------------------------
+
+func release(v interface{}) {
+	if r, ok := v.(Releaser); ok {
+		r.Release()
+	}
+}

--- a/stat/time.go
+++ b/stat/time.go
@@ -1,0 +1,18 @@
+package stat
+
+import "time"
+
+var start = time.Now()
+
+func init() {
+	AddStat("_stamp", "Stat generation timestamp", stamp)
+	AddStat("uptime", "Server uptime in seconds", uptime)
+}
+
+func stamp(_ Context) (interface{}, error) {
+	return time.Now(), nil
+}
+
+func uptime(_ Context) (interface{}, error) {
+	return time.Since(start), nil
+}


### PR DESCRIPTION
This PR adds core infrastructure for JSON stats publishing over HTTP.

Some sample stats are available at `8080:/status`

```json
{
  "_stamp": "2022-04-15T21:25:32.885158+05:00",
  "database": {
    "pool": {
      "MaxOpenConn": 0,
      "CurrOpenConn": 1,
      "BusyOpenConn": 0,
      "IdleOpenConn": 1
    }
  },
  "uptime": 4,
  "workers": {
    "status": {
      "offline": 18,
      "ready": 22,
      "onjob": 22,
      "paused": 14,
      "disabled": 24,
      "total": 100
    }
  }
}
```

**@jasonprado, @kepkap, @kevinmichaelchen:**

I need your feedback on what counters we want to monitor.