### PR TITLE
CI: Fix protobuf diff detection

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -58,7 +58,8 @@ jobs:
           OME_PGDB_ADDR: postgres://postgres:secret@postgres:5432/ome
 
       # Check to see if there were any protobuf changes
-      - uses: technote-space/get-diff-action@v6
+      - name: Check for protobuf changes
+        uses: technote-space/get-diff-action@v6
         id: git-diff
         with:
           PATTERNS: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
         id: git-diff
         with:
           PATTERNS: |
-            omeapi/**/*
+            api/**/*
 
       # Get JWT for our GitHub App.
       # This will be used only for the repository_dispatch in the next step.


### PR DESCRIPTION
Protobufs used to live under `omeapi`, but recently we moved them to live in `api`, so we have to update the part of our CI pipeline that checks for any changes to protobufs.